### PR TITLE
Update README.md to reflect new name of repo and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ The AWS and GitHub token variables are unset in the Jekyll subprocess so Jekyll 
 
 ### Development & making changes
 
-You'll need to have `docker` on your machine installed. If you just want to install the container image and run it, you can use `docker pull 18fgsa/federalist-docker-build`. `docker pull` behaves similarly to `git pull`. Run the container with `docker run 18fgsa/federalist-docker-build`.
+You'll need to have `docker` on your machine installed.
 
 If you want to make changes, you should first clone the repo and then build the docker container locally.
 
-0. `git clone git@github.com:18F/federalist-docker-build.git && cd federalist-docker-build`
-0. `docker build -t federalist-docker-build .`
-0. `docker run federalist-docker-build`
+0. `git clone git@github.com:18F/federalist-garden-build.git && cd federalist-garden-build`
+0. `docker build -t federalist-garden-build .`
+0. `docker run federalist-garden-build`
 
 After you make any changes to the container, you should run the `docker build` command again before `docker run`.
 
 In either case you'll want to supply your docker container with environment variables. `docker run` accepts an `-e` flag to designate environment variables. You must precede each key/value pair with the flag. For example:
-`docker run -e OWNER=18f -e REPOSITORY=18f.gsa.gov federalist-docker-build` (if you used `docker pull` this container image is probably named `18fgsa/federalist-docker-build`).
+`docker run -e OWNER=18f -e REPOSITORY=18f.gsa.gov federalist-garden-build`.
 
 ### Deploying to cloud.gov
 


### PR DESCRIPTION
...and also remove some outdated/unused instructions about pulling this image from the `18fgsa` docker registry.