### PR TITLE
Only include `--baseURL` arg when `BASEURL` exists

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,11 @@ if [ "$GENERATOR" = "jekyll" ]; then
 # Hugo
 elif [ "$GENERATOR" = "hugo" ]; then
   echo "[build.sh] Using hugo version: $(hugo version)"
-  hugo --baseURL ${BASEURL-"''"} --source . --destination ./_site
+  if [[ $BASEURL ]]; then
+    hugo --baseURL ${BASEURL} --source . --destination ./_site
+  else
+    hugo --source . --destination ./_site
+  fi
 
 # Static files
 else


### PR DESCRIPTION
and is non-empty.

Ref #72 for background info.