### PR TITLE
Update default node version to 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,8 @@ ENV LC_ALL en_US.UTF-8
 RUN dpkg-reconfigure --frontend noninteractive locales
 
 # Install nvm and install versions 4 and 6
-# TODO: Default to 6 LTS instead of 4
-# Ref: https://github.com/18F/federalist/issues/1209
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_DEFAULT_VERSION 4
+ENV NODE_DEFAULT_VERSION 8
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
   && . "$NVM_DIR/nvm.sh" \
   && nvm install $NODE_DEFAULT_VERSION \

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -64,9 +64,17 @@ def setup_node(ctx):
             npm_command = 'npm'
 
             if NVMRC_PATH.is_file():
+                # nvm will output the node and npm versions used
                 LOGGER.info('Using node version specified in .nvmrc')
                 ctx.run('nvm install')
                 npm_command = f'nvm use && {npm_command}'
+            else:
+                # output node and npm versions if the defaults are used
+                node_version_res = ctx.run(f'node --version', hide=True)
+                LOGGER.info(f'Node version: {node_version_res.stdout}')
+                npm_version_res = ctx.run(f'{npm_command} --version',
+                                          hide=True)
+                LOGGER.info(f'NPM version: {npm_version_res.stdout}')
 
             if PACKAGE_JSON_PATH.is_file():
                 LOGGER.info('Installing production dependencies '

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -15,7 +15,11 @@ from tasks.build import node_context
 
 class TestSetupNode():
     def test_it_is_callable(self):
-        ctx = MockContext(run=Result(''))
+        ctx = MockContext(run=[
+            Result('node version result'),
+            Result('npm version result'),
+            Result('npm install result'),
+        ])
         setup_node(ctx)
 
 


### PR DESCRIPTION
Ref #87 

While this is a simple technical change, it could likely impact any of our partners who were relying on the current v4 of node being the default version. @wslack should send out comms to users before we roll this out.

Before this is merged we should

- [x] Draft comms
- [ ]  Send internally
- [ ] Send externally