### PR TITLE
escape-quote flag values in main.py

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -164,6 +164,7 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
                 f'baseurl: {base_url}\n',
                 f'branch: {branch}\n',
                 config,
+                '\n',
             ])
 
     source_rvm = ctx.prefix(f'source {RVM_PATH}')

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -1,6 +1,7 @@
 '''Main task entrypoint'''
 
 import os
+import shlex
 
 from datetime import datetime
 
@@ -75,7 +76,9 @@ def run_task(ctx, task_name, private_values, log_callback,
     flag_args = []
     if flags_dict:
         for flag, val in flags_dict.items():
-            flag_args.append(f"{flag}='{val}'")
+            # quote val to prevent bash-breaking characters like '
+            quoted_val = shlex.quote(val)
+            flag_args.append(f"{flag}={quoted_val}")
 
     command = f'inv {task_name} {" ".join(flag_args)}'
 


### PR DESCRIPTION
to prevent special characters like `'` from causing bash errors, as described in #89