### PR TITLE
create _config.yml if it does not exist

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -157,14 +157,14 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
     Builds the cloned site with Jekyll
     '''
     # Add baseurl, branch, and the custom config to _config.yml
-    if JEKYLL_CONF_YML_PATH.is_file():
-        with open(JEKYLL_CONF_YML_PATH, 'a') as jekyll_conf_file:
-            jekyll_conf_file.writelines([
-                '\n'
-                f'baseurl: {base_url}\n',
-                f'branch: {branch}\n',
-                config,
-            ])
+    with open(JEKYLL_CONF_YML_PATH, 'a') as jekyll_conf_file:
+        jekyll_conf_file.writelines([
+            '\n'
+            f'baseurl: {base_url}\n',
+            f'branch: {branch}\n',
+            config,
+            '\n',
+        ])
 
     source_rvm = ctx.prefix(f'source {RVM_PATH}')
     with node_context(ctx, source_rvm, ctx.cd(CLONE_DIR_PATH)):

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -156,7 +156,8 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
     '''
     Builds the cloned site with Jekyll
     '''
-    # Add baseurl, branch, and the custom config to _config.yml
+    # Add baseurl, branch, and the custom config to _config.yml.
+    # Use the 'a' option to create or append to an existing config file.
     with open(JEKYLL_CONF_YML_PATH, 'a') as jekyll_conf_file:
         jekyll_conf_file.writelines([
             '\n'

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -2,6 +2,7 @@ import requests_mock
 
 from contextlib import ExitStack
 
+from pyfakefs.fake_filesystem_unittest import Patcher
 from invoke import MockContext, Result
 
 from tasks import (setup_node, run_federalist_script, setup_ruby,
@@ -48,15 +49,20 @@ class TestSetupRuby():
 
 
 class TestBuildJekyll():
-    def test_it_is_callable(self):
+    def test_it_is_callable(self, fs):
         ctx = MockContext(run=[
             Result('gem install jekyll result'),
             Result('jekyll version result'),
             Result('jekyll build result'),
         ])
-        build_jekyll(ctx, branch='branch', owner='owner',
-                     repository='repo', site_prefix='site/prefix',
-                     config='boop: beep', base_url='/site/prefix')
+
+        with Patcher() as patcher:
+            patcher.fs.CreateFile('/tmp/site_repo/_config.yml',
+                                  contents='hi: test')
+
+            build_jekyll(ctx, branch='branch', owner='owner',
+                         repository='repo', site_prefix='site/prefix',
+                         config='boop: beep', base_url='/site/prefix')
 
 
 class TestDownloadHugo():


### PR DESCRIPTION
This removes the existence check for a site's `_config.yml`, so that the file will be created if it doesn't already exist (in jekyll builds). Ref #92.