### PR TITLE
[WIP] Handle surrogate character error

### DIFF
--- a/log_utils/get_logger.py
+++ b/log_utils/get_logger.py
@@ -8,7 +8,15 @@ import sys
 import logging
 
 
-LOG_FORMATTER = logging.Formatter(
+class AsciiEncodingFormatter(logging.Formatter):
+    def format(self, record):
+        result = logging.Formatter.format(self, record)
+        # remove any invalid ascii characters
+        result = result.encode('ascii', 'replace').decode('ascii')
+        return result
+
+
+LOG_FORMATTER = AsciiEncodingFormatter(
     "[%(name)s] %(asctime)s %(levelname)s: %(message)s",
     datefmt='%Y-%m-%d %H:%M:%S',
 )

--- a/log_utils/get_logger.py
+++ b/log_utils/get_logger.py
@@ -8,15 +8,7 @@ import sys
 import logging
 
 
-class AsciiEncodingFormatter(logging.Formatter):
-    def format(self, record):
-        result = logging.Formatter.format(self, record)
-        # remove any invalid ascii characters
-        result = result.encode('ascii', 'replace').decode('ascii')
-        return result
-
-
-LOG_FORMATTER = AsciiEncodingFormatter(
+LOG_FORMATTER = logging.Formatter(
     "[%(name)s] %(asctime)s %(levelname)s: %(message)s",
     datefmt='%Y-%m-%d %H:%M:%S',
 )

--- a/publishing/SiteObject.py
+++ b/publishing/SiteObject.py
@@ -12,6 +12,18 @@ from datetime import datetime
 mimetypes.init()  # must initialize mimetypes
 
 
+def escape_surrogates(text):
+    '''
+    Escapes invalid surrogates in a unicode string.
+
+    >>> escape_surrogates('agency’s.html')
+    'agency’s.html'
+
+    from http://lucumr.pocoo.org/2013/7/2/the-updated-guide-to-unicode/
+    '''
+    return text.encode('utf-8', 'surrogateescape').decode('utf-8')
+
+
 def remove_prefix(text, prefix):
     '''Returns a copy of text with the given prefix removed'''
     if text.startswith(prefix):
@@ -37,7 +49,8 @@ class SiteObject():
         if self.dir_prefix:
             filename = remove_prefix(filename,
                                      path.join(self.dir_prefix, ''))
-        return f'{self.site_prefix}/{filename}'
+
+        return escape_surrogates(f'{self.site_prefix}/{filename}')
 
     def upload_to_s3(self, bucket, s3_client):
         '''Upload this object to S3'''
@@ -179,12 +192,12 @@ class SiteRedirect(SiteObject):
             if filename == self.dir_prefix:
                 # then this is 'root' site redirect object
                 # (ie, the main index.html file)
-                return self.site_prefix
+                return escape_surrogates(self.site_prefix)
 
             filename = remove_prefix(filename,
                                      path.join(self.dir_prefix, ''))
 
-        return f'{self.site_prefix}/{filename}'
+        return escape_surrogates(f'{self.site_prefix}/{filename}')
 
     def upload_to_s3(self, bucket, s3_client):
         '''Uploads the redirect object to S3'''

--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -18,7 +18,7 @@ LOGGER = get_logger('S3_PUBLISHER')
 def list_remote_objects(bucket, site_prefix, s3_client):
     '''
     Generates a list of remote S3 objects that have keys starting with
-    site_preix in the given bucket.
+    site_prefix in the given bucket.
     '''
     results_truncated = True
     continuation_token = None

--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import boto3
 
 from log_utils import get_logger
-from .SiteObject import (remove_prefix, SiteObject, SiteFile, SiteRedirect)
+from .SiteObject import remove_prefix, SiteObject, SiteFile, SiteRedirect
 
 LOGGER = get_logger('S3_PUBLISHER')
 
@@ -135,6 +135,12 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, cache_control,
     new_objects = []
     modified_objects = []
     for local_filename, local_obj in local_objects_by_filename.items():
+
+        # TODO: there is a mismatch between localfilenames and the filenames (keys)
+        # coming back from S3 if there are escaped surrogates in the remote files.
+        # This prevents us from properly matching local files against the remote files
+        # and results in incorrect deletions.
+
         matching_remote_obj = remote_objects_by_filename.get(local_filename)
         if not matching_remote_obj:
             new_objects.append(local_obj)


### PR DESCRIPTION
To continue later. Ref #98.

We are able to upload keys to s3 for files with surrogate characters by using `text.encode('utf-8', 'surrogateescape').decode('utf-8')`.

However, on subsequent publishes of the same repo, since the file **s3 key** is then different from the local (ie the repo's) file **name**, our code to detect new/modified/deleted files breaks down. We'll need to update that logic to handle the modified `surrogateescape`'d keys, perhaps by looking at the existing objects' `Filename`s instead of only at their `Key`s.

