### PR TITLE
Skip files with invalid surrogates in file names

### DIFF
--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -161,7 +161,14 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, cache_control,
             LOGGER.info(f'Uploading {file.s3_key}')
             start_time = datetime.now()
 
-            file.upload_to_s3(bucket, s3_client)
+            try:
+                file.upload_to_s3(bucket, s3_client)
+            except UnicodeEncodeError as err:
+                if err.reason == 'surrogates not allowed':
+                    LOGGER.warn(f'... unable to upload {file.filename} due '
+                                f'to invalid characters in file name.')
+                else:
+                    raise
 
             delta = datetime.now() - start_time
             LOGGER.info(f'... done in {delta.total_seconds():.2f}s')


### PR DESCRIPTION
and log a warning. This is a temporary mitigation for #98.
