### PR TITLE
Update pyinvoke to 0.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-invoke==0.21.0
+invoke==0.22.0
 python-dotenv==0.7.1
 requests==2.18.4
 boto3==1.4.7


### PR DESCRIPTION
No breaking changes according to the [changelog](http://www.pyinvoke.org/changelog.html#0.22.0), only bugfixes and dropped support for older versions of python.