### PR TITLE
When logging, send both stdout and stderr

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = test/*
+omit = test/* echo-server/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ docker-compose.yml
 Dockerfile
 tmp
 test-run.sh
+echo-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,22 @@ services:
     volumes:
       - .:/app
     links:
-      - httpecho
+      - echoserver
     depends_on:
-      - httpecho
+      - echoserver
     environment:
-      FEDERALIST_BUILDER_CALLBACK: http://httpecho:8080/delete
-      STATUS_CALLBACK: http://httpecho:8080/post
-      LOG_CALLBACK: http://httpecho:8080/post
+      FEDERALIST_BUILDER_CALLBACK: http://echoserver:8989/builder
+      STATUS_CALLBACK: http://echoserver:8989/status
+      LOG_CALLBACK: http://echoserver:8989/log
 
-  httpecho:
-    # TODO: probably not necessary actually?
-    image: solsson/http-echo:latest
+  echoserver:
+    # simple python server to log requests during development
+    build:
+      context: ./echo-server
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./echo-server:/code
     environment:
-      PORT: 8080
+      PORT: 8989
+    ports:
+      - "8989:8989"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         is_testing: 1
     volumes:
-      - .:/app
+      - .:/app:delegated
     links:
       - echoserver
     depends_on:

--- a/echo-server/Dockerfile
+++ b/echo-server/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6-alpine
+
+WORKDIR /code
+ADD run.py /code
+
+EXPOSE 8989
+
+CMD ["python", "run.py"]

--- a/echo-server/run.py
+++ b/echo-server/run.py
@@ -1,0 +1,81 @@
+# Reflects the requests from HTTP methods GET, POST, PUT, and DELETE
+#
+# Based on https://gist.github.com/1kastner/e083f9e813c0464e6a2ec8910553e632
+
+import os
+import base64
+import json
+import threading
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+def flush_print(s):
+    print(s, flush=True)
+
+
+def decodeb64(s):
+    return str(base64.b64decode(s), 'utf-8')
+
+
+class StoppableHTTPServer(HTTPServer):
+    def run(self):
+        try:
+            self.serve_forever()
+        except Exception:  # pylint: disable=W0703
+            pass
+        finally:
+            self.server_close()
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        flush_print("\n----- Request Start ----->\n")
+        flush_print(f"{self.command} : {self.path}")
+        flush_print("<----- Request End -----\n")
+
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        flush_print("\n----- Request Start ----->\n")
+        flush_print(f"{self.command} : {self.path}")
+
+        content_length = self.headers.get('Content-Length')
+        length = int(content_length) if content_length else 0
+        payload = self.rfile.read(length)
+
+        content_type = self.headers.get('Content-Type')
+        if content_type == 'application/json':
+            flush_print('Decoding encoded JSON payload...')
+            payload_json = json.loads(str(payload, 'utf-8'))
+            if payload_json.get('output'):
+                payload_json['output'] = decodeb64(payload_json['output'])
+            if payload_json.get('message'):
+                payload_json['message'] = decodeb64(payload_json['message'])
+
+            payload = json.dumps(payload_json)
+
+        flush_print(f"Request payload: {payload}")
+        flush_print("<----- Request End -----\n")
+
+        self.send_response(200)
+        self.end_headers()
+
+    do_PUT = do_POST
+    do_DELETE = do_GET
+
+
+def main():
+    port = int(os.getenv('PORT', 8080))
+    host = os.getenv('HOST', '0.0.0.0')
+    print(f'Listening on {host}:{port}')
+    server = StoppableHTTPServer((host, port), RequestHandler)
+
+    # Start processing requests
+    thread = threading.Thread(None, server.run)
+    thread.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -197,9 +197,14 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
         jekyll_vers_res = ctx.run(f'{jekyll_cmd} -v')
         LOGGER.info(f'Building using Jekyll version: {jekyll_vers_res.stdout}')
 
+        jekyll_build_env = build_env(branch, owner, repository, site_prefix,
+                                     base_url)
+        # Use JEKYLL_ENV to tell jekyll to run in production mode
+        jekyll_build_env['JEKYLL_ENV'] = 'production'
+
         ctx.run(
             f'{jekyll_cmd} build --destination {SITE_BUILD_DIR_PATH}',
-            env=build_env(branch, owner, repository, site_prefix, base_url)
+            env=jekyll_build_env
         )
 
 

--- a/test/test_remote_logs.py
+++ b/test/test_remote_logs.py
@@ -36,12 +36,27 @@ class TestPostOutputLog():
         })
 
     @patch('requests.post')
-    def test_log_is_truncated(self, mock_post):
-        post_output_log(MOCK_LOG_URL, 'test', 'boopboop', limit=4)
-        mock_post.assert_called_once_with(MOCK_LOG_URL, json={
-            'source': 'test',
-            'output': b64string('boop'),
-        })
+    def test_logs_are_chunked(self, mock_post):
+        post_output_log(MOCK_LOG_URL, 'test', 'abcdefg', chunk_size=2)
+
+        assert mock_post.call_count == 4
+
+        mock_post.assert_any_call(
+            MOCK_LOG_URL,
+            json={'source': 'test', 'output': b64string('ab')}
+        )
+        mock_post.assert_any_call(
+            MOCK_LOG_URL,
+            json={'source': 'test', 'output': b64string('cd')}
+        )
+        mock_post.assert_any_call(
+            MOCK_LOG_URL,
+            json={'source': 'test', 'output': b64string('ef')}
+        )
+        mock_post.assert_any_call(
+            MOCK_LOG_URL,
+            json={'source': 'test', 'output': b64string('g')}
+        )
 
     @patch('requests.post')
     def test_it_does_not_post_if_SKIP_LOGGING(self, mock_post, monkeypatch):


### PR DESCRIPTION
ref #113

also:
  - add a new helpful docker image to reflect logging requests during development
  - instead of truncating logs, chunk them into multiple pieces and log each piece