### PR TITLE
Set JEKYLL_ENV=production during jekyll builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         is_testing: 1
     volumes:
-      - .:/app
+      - .:/app:delegated
     links:
       - echoserver
     depends_on:

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -197,9 +197,14 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
         jekyll_vers_res = ctx.run(f'{jekyll_cmd} -v')
         LOGGER.info(f'Building using Jekyll version: {jekyll_vers_res.stdout}')
 
+        jekyll_build_env = build_env(branch, owner, repository, site_prefix,
+                                     base_url)
+        # Use JEKYLL_ENV to tell jekyll to run in production mode
+        jekyll_build_env['JEKYLL_ENV'] = 'production'
+
         ctx.run(
             f'{jekyll_cmd} build --destination {SITE_BUILD_DIR_PATH}',
-            env=build_env(branch, owner, repository, site_prefix, base_url)
+            env=jekyll_build_env
         )
 
 


### PR DESCRIPTION
**Open against `113-log-stdout-and-stderr` (#114)**. Will retarget to `staging` once #114 is merged.

Ref: https://github.com/18F/federalist/issues/1545

cc @s2t2