### PR TITLE
[DO NOT MERGE] Remove `JEKYLL_ENV` from jekyll build task env

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -199,9 +199,6 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
 
         jekyll_build_env = build_env(branch, owner, repository, site_prefix,
                                      base_url)
-        # Use JEKYLL_ENV to tell jekyll to run in production mode
-        jekyll_build_env['JEKYLL_ENV'] = 'production'
-
         ctx.run(
             f'{jekyll_cmd} build --destination {SITE_BUILD_DIR_PATH}',
             env=jekyll_build_env

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -100,8 +100,7 @@ class TestBuildJekyll():
                                      'REPOSITORY': 'repo',
                                      'SITE_PREFIX': 'site/prefix',
                                      'BASEURL': '/site/prefix',
-                                     'LANG': 'en_US.UTF-8',
-                                     'JEKYLL_ENV': 'production'}
+                                     'LANG': 'en_US.UTF-8'}
 
 
 class TestDownloadHugo():


### PR DESCRIPTION
This was deployed as a hotfix to production to help resolve an issue with the `fedramp-gov` site on 2/7/18.

This PR should not be merged -- it's here to serve as a reminder to remove the hotfix once `fedramp-gov` is able to amend their site. Ref https://github.com/GSA/fedramp-gov/pull/59

cc @wslack 