### PR TITLE
[DO NOT MERGE] Remove JEKYLL_ENV

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -200,7 +200,7 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
         jekyll_build_env = build_env(branch, owner, repository, site_prefix,
                                      base_url)
         # Use JEKYLL_ENV to tell jekyll to run in production mode
-        jekyll_build_env['JEKYLL_ENV'] = 'production'
+        # jekyll_build_env['JEKYLL_ENV'] = 'production'
 
         ctx.run(
             f'{jekyll_cmd} build --destination {SITE_BUILD_DIR_PATH}',

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -100,8 +100,7 @@ class TestBuildJekyll():
                                      'REPOSITORY': 'repo',
                                      'SITE_PREFIX': 'site/prefix',
                                      'BASEURL': '/site/prefix',
-                                     'LANG': 'en_US.UTF-8',
-                                     'JEKYLL_ENV': 'production'}
+                                     'LANG': 'en_US.UTF-8',}
 
 
 class TestDownloadHugo():


### PR DESCRIPTION
This is a reminder PR. `JEKYLL_ENV` has been removed due to another issue with the fedramp-gov site and its use of the `github-pages` Jekyll plugin.

This version of the code is currently live in production.

Once fedramp-gov can remove `github-pages` or mitigate the problems it causes in their live site, we should close this PR and launch the `master` code branch back to production.

cc @wslack 