### PR TITLE
Reduce size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.6-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       apt-utils build-essential git curl libssl-dev \
-      libreadline-dev zlib1g-dev libffi-dev
+      libreadline-dev zlib1g-dev libffi-dev \
+      python2.7
 
 # Install and setup en_US.UTF-8 locale
 # This is necessary so that output from node/ruby/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-slim
 
 # Install general dependencies
 RUN apt-get update \
@@ -34,13 +34,12 @@ RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | b
 
 # Install ruby via rvm
 ENV RUBY_VERSION 2.3.1
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-RUN \curl -sSL https://get.rvm.io | bash -s stable
-RUN /bin/bash -l -c 'rvm install $RUBY_VERSION && rvm use --default $RUBY_VERSION'
-RUN echo rvm_silence_path_mismatch_check_flag=1 >> /etc/rvmrc
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+  && \curl -sSL https://get.rvm.io | bash -s stable \
+  && /bin/bash -l -c 'rvm install $RUBY_VERSION && rvm use --default $RUBY_VERSION' \
+  && echo rvm_silence_path_mismatch_check_flag=1 >> /etc/rvmrc \
+  && echo 'install: --no-document\nupdate: --no-document' >> "/etc/.gemrc"
 
-# skip installing gem documentation
-RUN echo 'install: --no-document\nupdate: --no-document' >> "/etc/.gemrc"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM python:3.6-slim
+FROM python:3.6
 
 # Install general dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       apt-utils build-essential git curl libssl-dev \
-      libreadline-dev zlib1g-dev libffi-dev \
-      python2.7
+      libreadline-dev zlib1g-dev libffi-dev
 
 # Install and setup en_US.UTF-8 locale
 # This is necessary so that output from node/ruby/python

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -80,9 +80,6 @@ def setup_node(ctx):
             if PACKAGE_JSON_PATH.is_file():
                 LOGGER.info('Installing production dependencies '
                             'in package.json')
-                # node-gyp requires python 2, which we have installed
-                # so set npm to use it when necessary
-                ctx.run(f'{npm_command} config set python python2.7')
                 ctx.run(f'{npm_command} install --production')
 
 

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -80,7 +80,9 @@ def setup_node(ctx):
             if PACKAGE_JSON_PATH.is_file():
                 LOGGER.info('Installing production dependencies '
                             'in package.json')
-
+                # node-gyp requires python 2, which we have installed
+                # so set npm to use it when necessary
+                ctx.run(f'{npm_command} config set python python2.7')
                 ctx.run(f'{npm_command} install --production')
 
 


### PR DESCRIPTION
- ~Use `python:3.6-slim` as the base image.~
  - This caused problems with `node-sass` and `node-gyp` (see https://github.com/18F/federalist-garden-build/pull/120#issuecomment-370941560 for explanation), so I've removed this change.
- Reduces number of `RUN` statements by combining multiple into a single shell command (using the `&&` operator).

Ref #112. ~This seems to have reduced the image size from `1.07GB` to `684MB`, which is pretty excellent.~ After switching back to `python:3.6` as the base image, the image is back at `1.07GB` so no size savings unfortunately. I still think condensing the `RUN` commands is a good idea though.