### PR TITLE
Improve testing for publish, build, and common tasks

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: /test
+exclude: /test,/echo-server

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = test/* echo-server/*
+omit = */test/*, */echo-server/*

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
-coverage.xml
+coverage/
 *.cover
 .hypothesis/
 

--- a/publishing/SiteObject.py
+++ b/publishing/SiteObject.py
@@ -96,7 +96,7 @@ class SiteFile(SiteObject):
         '''Generates an md5 hash of the file contents'''
         hash_md5 = hashlib.md5()  # nosec
 
-        with open(self.filename, "rb") as file:
+        with open(self.filename, 'rb') as file:
             for chunk in iter(lambda: file.read(4096), b""):
                 hash_md5.update(chunk)
         return hash_md5.hexdigest()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-norecursedirs = _old .cache .vscode tmp 
-addopts = --doctest-modules --cov-report xml:./coverage/coverage.xml --cov-report term --cov
+norecursedirs = .cache .vscode tmp
+addopts = --doctest-modules --cov-report xml:./coverage/coverage.xml --cov-report html:./coverage --cov-report term --cov

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -2,25 +2,20 @@
 Build tasks and helpers
 '''
 
+import json
 import os
 import shlex
-
-from os import path
-
-import json
 import shutil
-
 from contextlib import ExitStack
+from os import path
 from pathlib import Path
 
 import requests
-from invoke import task, call
+from invoke import call, task
 
-from tasks.common import (
-    clean, CLONE_DIR_PATH, SITE_BUILD_DIR, SITE_BUILD_DIR_PATH,
-    WORKING_DIR_PATH)
 from log_utils import get_logger
-
+from tasks.common import (CLONE_DIR_PATH, SITE_BUILD_DIR, SITE_BUILD_DIR_PATH,
+                          WORKING_DIR_PATH, clean)
 
 LOGGER = get_logger('BUILD')
 
@@ -265,7 +260,10 @@ def build_hugo(ctx, branch, owner, repository, site_prefix,
 def build_static(ctx):
     '''Moves all files from CLONE_DIR into SITE_BUILD_DIR'''
     LOGGER.info(f'Moving files to {SITE_BUILD_DIR}')
-    os.makedirs(SITE_BUILD_DIR_PATH, exist_ok=True)
+
+    # Make the site build directory first
+    SITE_BUILD_DIR_PATH.mkdir(exist_ok=True)
+
     files = os.listdir(CLONE_DIR_PATH)
 
     for file in files:

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -16,10 +16,10 @@ from pathlib import Path
 import requests
 from invoke import task, call
 
+from tasks.common import (
+    clean, CLONE_DIR_PATH, SITE_BUILD_DIR, SITE_BUILD_DIR_PATH,
+    WORKING_DIR_PATH)
 from log_utils import get_logger
-from .common import (CLONE_DIR_PATH, SITE_BUILD_DIR,
-                     WORKING_DIR, SITE_BUILD_DIR_PATH,
-                     clean)
 
 
 LOGGER = get_logger('BUILD')
@@ -28,13 +28,11 @@ NVM_SH_PATH = Path('/usr/local/nvm/nvm.sh')
 RVM_PATH = Path('/usr/local/rvm/scripts/rvm')
 
 HUGO_BIN = 'hugo'
-HUGO_BIN_PATH = Path(path.join(WORKING_DIR), HUGO_BIN)
-
-PACKAGE_JSON_PATH = Path(path.join(CLONE_DIR_PATH, 'package.json'))
-NVMRC_PATH = Path(path.join(CLONE_DIR_PATH, '.nvmrc'))
-RUBY_VERSION_PATH = Path(path.join(CLONE_DIR_PATH), '.ruby-version')
-GEMFILE_PATH = Path(path.join(CLONE_DIR_PATH), 'Gemfile')
-JEKYLL_CONF_YML_PATH = Path(path.join(CLONE_DIR_PATH, '_config.yml'))
+NVMRC = '.nvmrc'
+PACKAGE_JSON = 'package.json'
+RUBY_VERSION = '.ruby-version'
+GEMFILE = 'Gemfile'
+JEKYLL_CONFIG_YML = '_config.yml'
 
 
 def has_federalist_script():
@@ -42,9 +40,9 @@ def has_federalist_script():
     Checks for existence of the "federalist" script in the
     cloned repo's package.json.
     '''
-
+    PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON
     if PACKAGE_JSON_PATH.is_file():
-        with open(PACKAGE_JSON_PATH) as json_file:
+        with PACKAGE_JSON_PATH.open() as json_file:
             package_json = json.load(json_file)
             return 'federalist' in package_json.get('scripts', {})
 
@@ -59,10 +57,11 @@ def setup_node(ctx):
     Uses the node version specified in the cloned repo's .nvmrc
     file if it is present.
     '''
-
-    with ctx.cd(CLONE_DIR_PATH):
+    with ctx.cd(str(CLONE_DIR_PATH)):
         with ctx.prefix(f'source {NVM_SH_PATH}'):
             npm_command = 'npm'
+
+            NVMRC_PATH = CLONE_DIR_PATH / NVMRC
 
             if NVMRC_PATH.is_file():
                 # nvm will output the node and npm versions used
@@ -77,6 +76,7 @@ def setup_node(ctx):
                                           hide=True)
                 LOGGER.info(f'NPM version: {npm_version_res.stdout}')
 
+            PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON
             if PACKAGE_JSON_PATH.is_file():
                 LOGGER.info('Installing production dependencies '
                             'in package.json')
@@ -98,6 +98,7 @@ def node_context(ctx, *more_contexts):
 
     # Only use `nvm use` if `.nvmrc` exists.
     # The default node version will be used if `.nvmrc` is not present.
+    NVMRC_PATH = CLONE_DIR_PATH / NVMRC
     if NVMRC_PATH.is_file():
         contexts.append(ctx.prefix('nvm use'))
 
@@ -121,24 +122,18 @@ def build_env(branch, owner, repository, site_prefix, base_url):
     }
 
 
-def _run_federalist_script(ctx, branch, owner, repository,
-                           site_prefix, base_url=''):
+@task(pre=[setup_node])
+def run_federalist_script(ctx, branch, owner, repository, site_prefix,
+                          base_url=''):
     '''
     Runs the npm "federalist" script if it is defined
     '''
-    if PACKAGE_JSON_PATH.is_file() and has_federalist_script():
-        with node_context(ctx, ctx.cd(CLONE_DIR_PATH)):
+    if has_federalist_script():
+        with node_context(ctx, ctx.cd(str(CLONE_DIR_PATH))):
             LOGGER.info('Running federalist build script in package.json')
-            ctx.run(
-                'npm run federalist',
-                env=build_env(branch, owner, repository,
-                              site_prefix, base_url)
-            )
-
-
-# 'Exported' run_federalist_script task
-run_federalist_script = task(
-    pre=[setup_node], name='run-federalist-script')(_run_federalist_script)
+            ctx.run('npm run federalist',
+                    env=build_env(branch, owner, repository, site_prefix,
+                                  base_url))
 
 
 @task
@@ -148,9 +143,10 @@ def setup_ruby(ctx):
     Uses the ruby version specified in .ruby-version if present
     '''
     with ctx.prefix(f'source {RVM_PATH}'):
+        RUBY_VERSION_PATH = CLONE_DIR_PATH / RUBY_VERSION
         if RUBY_VERSION_PATH.is_file():
             ruby_version = ''
-            with open(RUBY_VERSION_PATH, 'r') as ruby_vers_file:
+            with RUBY_VERSION_PATH.open() as ruby_vers_file:
                 ruby_version = ruby_vers_file.readline().strip()
                 # escape-quote the value in case there's anything weird
                 # in the .ruby-version file
@@ -163,14 +159,17 @@ def setup_ruby(ctx):
         LOGGER.info(f'Ruby version: {ruby_ver_res.stdout}')
 
 
-def _build_jekyll(ctx, branch, owner, repository, site_prefix,
-                  config='', base_url=''):
+@task(pre=[setup_ruby])
+def build_jekyll(ctx, branch, owner, repository, site_prefix,
+                 config='', base_url=''):
     '''
     Builds the cloned site with Jekyll
     '''
+    JEKYLL_CONF_YML_PATH = CLONE_DIR_PATH / JEKYLL_CONFIG_YML
+
     # Add baseurl, branch, and the custom config to _config.yml.
     # Use the 'a' option to create or append to an existing config file.
-    with open(JEKYLL_CONF_YML_PATH, 'a') as jekyll_conf_file:
+    with JEKYLL_CONF_YML_PATH.open('a') as jekyll_conf_file:
         jekyll_conf_file.writelines([
             '\n'
             f'baseurl: {base_url}\n',
@@ -180,9 +179,10 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
         ])
 
     source_rvm = ctx.prefix(f'source {RVM_PATH}')
-    with node_context(ctx, source_rvm, ctx.cd(CLONE_DIR_PATH)):
+    with node_context(ctx, source_rvm, ctx.cd(str(CLONE_DIR_PATH))):
         jekyll_cmd = 'jekyll'
 
+        GEMFILE_PATH = CLONE_DIR_PATH / GEMFILE
         if GEMFILE_PATH.is_file():
             LOGGER.info('Setting up bundler')
             ctx.run('gem install bundler')
@@ -208,10 +208,6 @@ def _build_jekyll(ctx, branch, owner, repository, site_prefix,
         )
 
 
-# 'Exported' build_jekyll task
-build_jekyll = task(pre=[setup_ruby], name='build-jekyll')(_build_jekyll)
-
-
 @task
 def download_hugo(ctx, version='0.23'):
     '''
@@ -221,12 +217,15 @@ def download_hugo(ctx, version='0.23'):
     dl_url = (f'https://github.com/gohugoio/hugo/releases/download/'
               f'v{version}/hugo_{version}_Linux-64bit.tar.gz')
     response = requests.get(dl_url)
-    hugo_tar_path = path.join(WORKING_DIR, 'hugo.tar.gz')
-    with open(hugo_tar_path, 'wb') as hugo_tar:
+
+    hugo_tar_path = WORKING_DIR_PATH / 'hugo.tar.gz'
+    with hugo_tar_path.open('wb') as hugo_tar:
         for chunk in response.iter_content(chunk_size=128):
             hugo_tar.write(chunk)
 
-    ctx.run(f'tar -xzf {hugo_tar_path} -C {WORKING_DIR}')
+    HUGO_BIN_PATH = WORKING_DIR_PATH / HUGO_BIN
+
+    ctx.run(f'tar -xzf {hugo_tar_path} -C {WORKING_DIR_PATH}')
     ctx.run(f'chmod +x {HUGO_BIN_PATH}')
 
 
@@ -239,6 +238,8 @@ def build_hugo(ctx, branch, owner, repository, site_prefix,
     # Note that no pre- or post-tasks will be called when calling
     # the download_hugo task this way
     download_hugo(ctx, hugo_version)
+
+    HUGO_BIN_PATH = WORKING_DIR_PATH / HUGO_BIN
 
     hugo_vers_res = ctx.run(f'{HUGO_BIN_PATH} version')
     LOGGER.info(f'hugo version: {hugo_vers_res.stdout}')
@@ -257,7 +258,11 @@ def build_hugo(ctx, branch, owner, repository, site_prefix,
         )
 
 
-def _build_static(ctx):
+@task(pre=[
+    # Remove cloned repo's .git directory
+    call(clean, which=path.join(CLONE_DIR_PATH, '.git')),
+])
+def build_static(ctx):
     '''Moves all files from CLONE_DIR into SITE_BUILD_DIR'''
     LOGGER.info(f'Moving files to {SITE_BUILD_DIR}')
     os.makedirs(SITE_BUILD_DIR_PATH, exist_ok=True)
@@ -266,13 +271,5 @@ def _build_static(ctx):
     for file in files:
         # don't move the SITE_BUILD_DIR dir into itself
         if file is not SITE_BUILD_DIR:
-            shutil.move(path.join(CLONE_DIR_PATH, file),
-                        SITE_BUILD_DIR_PATH)
-
-
-# 'Exported' build-static task
-build_static = task(
-    pre=[
-        # Remove cloned repo's .git directory
-        call(clean, which=path.join(CLONE_DIR_PATH, '.git')),
-    ], name='build-static')(_build_static)
+            shutil.move(str(CLONE_DIR_PATH / file),
+                        str(SITE_BUILD_DIR_PATH))

--- a/tasks/clone.py
+++ b/tasks/clone.py
@@ -82,7 +82,7 @@ def push_repo_remote(ctx, owner, repository, branch,
 
     github_token = os.environ['GITHUB_TOKEN']
 
-    with ctx.cd(CLONE_DIR_PATH):
+    with ctx.cd(str(CLONE_DIR_PATH)):
         ctx.run(f'git remote add {remote_name} '
                 f'{clone_url(owner, repository, github_token)}')
         ctx.run(f'git push {remote_name} {branch}:master')

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -5,6 +5,7 @@ Common variables, tasks, and functions
 import shutil
 
 from os import path
+from pathlib import Path
 from datetime import timedelta  # noqa pylint: disable=W0611
 
 from invoke import task
@@ -13,22 +14,22 @@ from dotenv import load_dotenv as _load_dotenv
 from log_utils import get_logger
 
 REPO_BASE_URL = 'github.com'
-WORKING_DIR = path.join(path.sep, 'tmp')
+WORKING_DIR_PATH = Path('/tmp')
 
 CLONE_DIR = 'site_repo'
-CLONE_DIR_PATH = path.join(WORKING_DIR, CLONE_DIR)
+CLONE_DIR_PATH = WORKING_DIR_PATH / CLONE_DIR
 
 SITE_BUILD_DIR = '_site'
 
-BASE_DIR = path.dirname(path.dirname(__file__))
-DOTENV_PATH = path.join(BASE_DIR, '.env')
+BASE_DIR = Path(path.dirname(path.dirname(__file__)))
+DOTENV_PATH = BASE_DIR / '.env'
 
-SITE_BUILD_DIR_PATH = path.join(CLONE_DIR_PATH, SITE_BUILD_DIR)
+SITE_BUILD_DIR_PATH = CLONE_DIR_PATH / SITE_BUILD_DIR
 
 LOGGER = get_logger('COMMON')
 
 
-def load_dotenv():
+def load_dotenv():  # pragma: no cover
     '''Loads environment from a .env file'''
     if path.exists(DOTENV_PATH):
         LOGGER.info('Loading environment from .env file')

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -14,7 +14,13 @@ from dotenv import load_dotenv as _load_dotenv
 from log_utils import get_logger
 
 REPO_BASE_URL = 'github.com'
-WORKING_DIR_PATH = Path('/tmp')
+
+# We use the `/tmp` folder to hold the cloned, and later the built,
+# client site and repository. Using a predictable path in our
+# ephemeral build containers is ok and does not present any
+# security issues because no sensitive information is stored there;
+# it only holds the client site code. Thus, marked as nosec.
+WORKING_DIR_PATH = Path('/tmp')  # nosec
 
 CLONE_DIR = 'site_repo'
 CLONE_DIR_PATH = WORKING_DIR_PATH / CLONE_DIR

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -15,12 +15,10 @@ from log_utils import get_logger
 
 REPO_BASE_URL = 'github.com'
 
-# We use the `/tmp` folder to hold the cloned, and later the built,
-# client site and repository. Using a predictable path in our
-# ephemeral build containers is ok and does not present any
-# security issues because no sensitive information is stored there;
-# it only holds the client site code. Thus, marked as nosec.
-WORKING_DIR_PATH = Path('/tmp')  # nosec
+WORKING_DIR_PATH = Path('/work')
+
+# Make the working directory if it doesn't exist
+WORKING_DIR_PATH.mkdir(exist_ok=True)
 
 CLONE_DIR = 'site_repo'
 CLONE_DIR_PATH = WORKING_DIR_PATH / CLONE_DIR

--- a/test/support.py
+++ b/test/support.py
@@ -1,0 +1,15 @@
+import tempfile
+
+from pathlib import Path
+
+
+def patch_dir(monkeypatch, module, dir_constant):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        monkeypatch.setattr(module, dir_constant, tmpdir_path)
+        yield tmpdir_path
+
+
+def create_file(file_path, contents='', mode='w'):
+    with file_path.open(mode) as f:
+        f.write(contents)

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -194,7 +194,7 @@ class TestDownloadHugo():
         with requests_mock.Mocker() as m:
             m.get(
                 'https://github.com/gohugoio/hugo/releases/download'
-                '/v0.23/hugo_0.23_Linux-64bit.tar.gz')
+                '/v0.23/hugo_0.23_Linux-64bit.tar.gz', text='fake-data')
             tasks.download_hugo(ctx)
 
     def test_it_accepts_other_versions(self):

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,28 +1,53 @@
-import requests_mock
-
-from unittest.mock import Mock
+import json
+import os
 from contextlib import ExitStack
+from unittest.mock import Mock
 
-from pyfakefs.fake_filesystem_unittest import Patcher
+import pytest
+import requests_mock
 from invoke import MockContext, Result
 
-from tasks import (setup_node, run_federalist_script, setup_ruby,
-                   build_jekyll, download_hugo, build_hugo, build_static)
+import tasks
+from tasks.build import (GEMFILE, HUGO_BIN, JEKYLL_CONFIG_YML, NVMRC,
+                         PACKAGE_JSON, RUBY_VERSION, node_context)
 
-from tasks.build import node_context
+from .support import create_file, patch_dir
 
-# TODO: use pyfakefs to setup PACKAGE_JSON_PATH, NVM_SH_PATH, etc
-# so we can test those code paths
+# TODO: Figure out how to test/ensure that pre-tasks are properly
+# specified
+
+
+@pytest.fixture
+def patch_clone_dir(monkeypatch):
+    yield from patch_dir(monkeypatch, tasks.build, 'CLONE_DIR_PATH')
+
+
+@pytest.fixture
+def patch_working_dir(monkeypatch):
+    yield from patch_dir(monkeypatch, tasks.build, 'WORKING_DIR_PATH')
+
+
+@pytest.fixture
+def patch_site_build_dir(monkeypatch):
+    yield from patch_dir(monkeypatch, tasks.build, 'SITE_BUILD_DIR_PATH')
 
 
 class TestSetupNode():
-    def test_it_is_callable(self):
-        ctx = MockContext(run=[
-            Result('node version result'),
-            Result('npm version result'),
-            Result('npm install result'),
-        ])
-        setup_node(ctx)
+    def test_it_uses_nvmrc_file_if_it_exists(self, patch_clone_dir):
+        create_file(patch_clone_dir / NVMRC, contents='6')
+        ctx = MockContext(run={
+            'nvm install': Result(),
+        })
+        tasks.setup_node(ctx)
+
+    def test_installs_production_deps(self, patch_clone_dir):
+        create_file(patch_clone_dir / PACKAGE_JSON)
+        ctx = MockContext(run={
+            'node --version': Result(),
+            'npm --version': Result(),
+            'npm install --production': Result(),
+        })
+        tasks.setup_node(ctx)
 
 
 class TestNodeContext():
@@ -32,6 +57,13 @@ class TestNodeContext():
         assert type(context_stack) == ExitStack
         assert len(context_stack._exit_callbacks) == 1
 
+    def test_it_appends_nvm_when_nvmrc_exists(self, patch_clone_dir):
+        create_file(patch_clone_dir / NVMRC, '4.2')
+        ctx = MockContext()
+        context_stack = node_context(ctx)
+        assert type(context_stack) == ExitStack
+        assert len(context_stack._exit_callbacks) == 2
+
     def test_node_context_accepts_more_contexts(self):
         ctx = MockContext()
         context_stack = node_context(ctx, ctx.cd('boop'))
@@ -40,83 +72,133 @@ class TestNodeContext():
 
 
 class TestRunFederalistScript():
-    def test_it_is_callable(self):
+    def test_it_runs_federalist_script_when_it_exists(self, patch_clone_dir):
+        package_json_contents = json.dumps({
+            'scripts': {
+                'federalist': 'echo hi',
+            },
+        })
+        create_file(patch_clone_dir / PACKAGE_JSON, package_json_contents)
+        ctx = MockContext(run={
+            'npm run federalist': Result(),
+        })
+        tasks.run_federalist_script(ctx, branch='branch', owner='owner',
+                                    repository='repo',
+                                    site_prefix='site/prefix',
+                                    base_url='/site/prefix')
+
+    def test_it_does_not_run_otherwise(self, patch_clone_dir):
         ctx = MockContext()
-        run_federalist_script(ctx, branch='branch', owner='owner',
-                              repository='repo', site_prefix='site/prefix',
-                              base_url='/site/prefix')
+        kwargs = dict(branch='branch', owner='owner',
+                      repository='repo',
+                      site_prefix='site/prefix',
+                      base_url='/site/prefix')
+        tasks.run_federalist_script(ctx, **kwargs)
 
 
 class TestSetupRuby():
     def test_it_is_callable(self):
-        ctx = MockContext(run=Result('ruby -v result'))
-        setup_ruby(ctx)
+        ctx = MockContext(run={
+            'ruby -v': Result(),
+        })
+        tasks.setup_ruby(ctx)
+
+    def test_it_uses_ruby_version_if_it_exists(self, patch_clone_dir):
+        create_file(patch_clone_dir / RUBY_VERSION, '2.3')
+        ctx = MockContext(run={
+            'rvm install 2.3': Result(),
+            'ruby -v': Result(),
+        })
+        tasks.setup_ruby(ctx)
+
+        # ruby_version should be strippeed and quoted as well
+        create_file(patch_clone_dir / RUBY_VERSION, '  $2.2  ')
+        ctx = MockContext(run={
+            "rvm install '$2.2'": Result(),
+            'ruby -v': Result(),
+        })
+        tasks.setup_ruby(ctx)
 
 
 class TestBuildJekyll():
-    def test_it_is_callable(self, fs):
+    def test_it_is_callable(self, patch_clone_dir):
         ctx = MockContext(run=[
             Result('gem install jekyll result'),
             Result('jekyll version result'),
             Result('jekyll build result'),
         ])
 
-        with Patcher() as patcher:
-            patcher.fs.CreateFile('/tmp/site_repo/_config.yml',
-                                  contents='hi: test')
+        contents = 'hi: test'
+        create_file(patch_clone_dir / JEKYLL_CONFIG_YML, contents)
+        tasks.build_jekyll(ctx, branch='branch', owner='owner',
+                           repository='repo', site_prefix='site/prefix',
+                           config='boop: beep', base_url='/site/prefix')
 
-            build_jekyll(ctx, branch='branch', owner='owner',
-                         repository='repo', site_prefix='site/prefix',
-                         config='boop: beep', base_url='/site/prefix')
-
-    def test_jekyll_build_is_called_correctly(self, fs):
-        ctx = MockContext(run=[
-            Result('gem install jekyll result'),
-            Result('jekyll version result'),
-            Result('jekyll build result'),
-        ])
-
+    def test_jekyll_build_is_called_correctly(self, patch_clone_dir):
+        ctx = MockContext()
         ctx.run = Mock()
 
-        with Patcher() as patcher:
-            patcher.fs.CreateFile('/tmp/site_repo/_config.yml',
-                                  contents='hi: test')
+        conf_path = patch_clone_dir / JEKYLL_CONFIG_YML
+        conf_contents = 'hi: test'
+        create_file(conf_path, conf_contents)
 
-            build_jekyll(ctx, branch='branch', owner='owner',
-                         repository='repo', site_prefix='site/prefix',
-                         config='boop: beep', base_url='/site/prefix')
+        tasks.build_jekyll(ctx, branch='branch', owner='owner',
+                           repository='repo', site_prefix='site/prefix',
+                           config='boop: beep', base_url='/site/prefix')
 
-            assert ctx.run.call_count == 3
+        assert ctx.run.call_count == 3
 
-            jekyll_build_call_args = ctx.run.call_args_list[2]
-            args, kwargs = jekyll_build_call_args
+        jekyll_build_call_args = ctx.run.call_args_list[2]
+        args, kwargs = jekyll_build_call_args
 
-            # Make sure the call to jekyll build is correct
-            assert args[0] == 'jekyll build --destination /tmp/site_repo/_site'
+        # Make sure the call to jekyll build is correct
+        assert args[0] == 'jekyll build --destination /tmp/site_repo/_site'
 
-            # Make sure the env is as expected
-            assert kwargs['env'] == {'BRANCH': 'branch',
-                                     'OWNER': 'owner',
-                                     'REPOSITORY': 'repo',
-                                     'SITE_PREFIX': 'site/prefix',
-                                     'BASEURL': '/site/prefix',
-                                     'LANG': 'en_US.UTF-8',
-                                     'JEKYLL_ENV': 'production'}
+        # Make sure the env is as expected
+        assert kwargs['env'] == {'BRANCH': 'branch',
+                                 'OWNER': 'owner',
+                                 'REPOSITORY': 'repo',
+                                 'SITE_PREFIX': 'site/prefix',
+                                 'BASEURL': '/site/prefix',
+                                 'LANG': 'en_US.UTF-8',
+                                 'JEKYLL_ENV': 'production'}
+
+        # Check that the config file has had baseurl, branch, and custom
+        # config added
+        with conf_path.open() as f:
+            assert f.read() == ('hi: test\nbaseurl: /site/prefix\n'
+                                'branch: branch\nboop: beep\n')
+
+    def test_gemfile_is_used_if_it_exists(self, monkeypatch, patch_clone_dir):
+        monkeypatch.setattr(tasks.build, 'SITE_BUILD_DIR_PATH', '/boop')
+        create_file(patch_clone_dir / GEMFILE, '')
+        ctx = MockContext(run={
+            'gem install bundler': Result(),
+            'bundle install': Result(),
+            'bundle exec jekyll -v': Result(),
+            f'bundle exec jekyll build --destination /boop': Result(),
+        })
+        tasks.build_jekyll(ctx, branch='branch', owner='owner',
+                           repository='repo', site_prefix='site/prefix')
 
 
 class TestDownloadHugo():
-    def test_it_is_callable(self):
-        ctx = MockContext(run=[
-            Result('tar result'),
-            Result('chmod result'),
-        ])
+    def test_it_is_callable(self, patch_working_dir):
+        tar_cmd = (f'tar -xzf {patch_working_dir}/hugo.tar.gz -C '
+                   f'{patch_working_dir}')
+        chmod_cmd = f'chmod +x {patch_working_dir}/hugo'
+        ctx = MockContext(run={
+            tar_cmd: Result(),
+            chmod_cmd: Result(),
+        })
         with requests_mock.Mocker() as m:
             m.get(
                 'https://github.com/gohugoio/hugo/releases/download'
                 '/v0.23/hugo_0.23_Linux-64bit.tar.gz')
-            download_hugo(ctx)
+            tasks.download_hugo(ctx)
 
     def test_it_accepts_other_versions(self):
+        version = '0.25'
         ctx = MockContext(run=[
             Result('tar result'),
             Result('chmod result'),
@@ -124,28 +206,52 @@ class TestDownloadHugo():
         with requests_mock.Mocker() as m:
             m.get(
                 'https://github.com/gohugoio/hugo/releases/download'
-                '/v0.25/hugo_0.25_Linux-64bit.tar.gz')
-            download_hugo(ctx, version='0.25')
+                f'/v{version}/hugo_{version}_Linux-64bit.tar.gz')
+            tasks.download_hugo(ctx, version=version)
 
 
 class TestBuildHugo():
-    def test_it_is_callable(self):
-        ctx = MockContext(run=[
-            Result('tar result'),
-            Result('chmod result'),
-            Result('hugo version result'),
-            Result('hugo build result'),
-        ])
+    def test_it_calls_hugo_as_expected(self, monkeypatch, patch_working_dir):
+        def mock_download(ctx, hugo_version):
+            pass
+
+        monkeypatch.setattr(tasks.build, 'download_hugo', mock_download)
+        hugo_path = patch_working_dir / HUGO_BIN
+        hugo_call = (f'{hugo_path} --source /tmp/site_repo '
+                     f'--destination /tmp/site_repo/_site')
+        ctx = MockContext(run={
+            f'{hugo_path} version': Result(),
+            hugo_call: Result(),
+        })
         with requests_mock.Mocker() as m:
             m.get(
                 'https://github.com/gohugoio/hugo/releases/download'
                 '/v0.23/hugo_0.23_Linux-64bit.tar.gz')
-            build_hugo(ctx, branch='branch', owner='owner',
-                       repository='repo', site_prefix='site/prefix',
-                       base_url='/site/prefix', hugo_version='0.23')
+            kwargs = dict(branch='branch', owner='owner',
+                          repository='repo', site_prefix='site/prefix')
+            tasks.build_hugo(ctx, **kwargs)
+
+            # and with base_url specified
+            kwargs['base_url'] = '/test_base'
+            hugo_call += f' --baseUrl /test_base'
+            ctx = MockContext(run={
+                f'{hugo_path} version': Result(),
+                hugo_call: Result(),
+            })
+            tasks.build_hugo(ctx, **kwargs)
 
 
 class TestBuildstatic():
-    def test_it_is_callable(self):
+    def test_it_moves_files_correctly(self, patch_site_build_dir,
+                                      patch_clone_dir):
         ctx = MockContext()
-        build_static(ctx)
+        for i in range(0, 10):
+            create_file(patch_clone_dir / f'file_{i}.txt', str(i))
+
+        assert len(os.listdir(patch_clone_dir)) == 10
+        assert len(os.listdir(patch_site_build_dir)) == 0
+
+        tasks.build_static(ctx)
+
+        assert len(os.listdir(patch_clone_dir)) == 0
+        assert len(os.listdir(patch_site_build_dir)) == 10

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -152,7 +152,7 @@ class TestBuildJekyll():
         args, kwargs = jekyll_build_call_args
 
         # Make sure the call to jekyll build is correct
-        assert args[0] == 'jekyll build --destination /tmp/site_repo/_site'
+        assert args[0] == 'jekyll build --destination /work/site_repo/_site'
 
         # Make sure the env is as expected
         assert kwargs['env'] == {'BRANCH': 'branch',
@@ -206,7 +206,8 @@ class TestDownloadHugo():
         with requests_mock.Mocker() as m:
             m.get(
                 'https://github.com/gohugoio/hugo/releases/download'
-                f'/v{version}/hugo_{version}_Linux-64bit.tar.gz')
+                f'/v{version}/hugo_{version}_Linux-64bit.tar.gz',
+                text='fake-data')
             tasks.download_hugo(ctx, version=version)
 
 
@@ -217,8 +218,8 @@ class TestBuildHugo():
 
         monkeypatch.setattr(tasks.build, 'download_hugo', mock_download)
         hugo_path = patch_working_dir / HUGO_BIN
-        hugo_call = (f'{hugo_path} --source /tmp/site_repo '
-                     f'--destination /tmp/site_repo/_site')
+        hugo_call = (f'{hugo_path} --source /work/site_repo '
+                     f'--destination /work/site_repo/_site')
         ctx = MockContext(run={
             f'{hugo_path} version': Result(),
             hugo_call: Result(),

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,40 @@
+import shutil
+
+import pytest
+
+from invoke import MockContext
+
+import tasks
+from .support import patch_dir
+
+
+@pytest.fixture
+def patch_clone_dir(monkeypatch):
+    yield from patch_dir(monkeypatch, tasks.common, 'CLONE_DIR_PATH')
+
+
+class TestClean():
+    def test_cleans_clone_dir_by_default(self, monkeypatch, patch_clone_dir):
+        ctx = MockContext()
+
+        def mock_rmtree(which, ignore_errors=False):
+            assert str(which) == str(patch_clone_dir)
+
+        monkeypatch.setattr(shutil, 'rmtree', mock_rmtree)
+        tasks.clean(ctx)
+        # clear the patch so that the temp patch_clone_dir
+        # will also be properly deleted upon exit
+        monkeypatch.undo()
+
+    def test_cleans_specified_dir(self, monkeypatch):
+        ctx = MockContext()
+
+        def mock_rmtree(which, ignore_errors=False):
+            assert str(which) == '/whatever'
+
+        monkeypatch.setattr(shutil, 'rmtree', mock_rmtree)
+        tasks.clean(ctx, which='/whatever')
+
+        # clear the patch so that the temp patch_clone_dir
+        # will also be properly deleted upon exit
+        monkeypatch.undo()

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1,18 +1,18 @@
-import os
-
 import boto3
 
 from moto import mock_s3
+
 from invoke import MockContext
 
 from tasks import publish
 
 
-class TestPublish():
+class TestPublishOld():
     @mock_s3
-    def test_it_is_callable(self):
-        os.environ['AWS_ACCESS_KEY_ID'] = 'fake_access_key'
-        os.environ['AWS_SECRET_ACCESS_KEY'] = 'fake_secret_key'
+    def test_it_is_callable(self, monkeypatch):
+        monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake-access-key')
+        monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake-secret-key')
+        
         ctx = MockContext()
 
         aws_region = 'region'

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -7,12 +7,12 @@ from invoke import MockContext
 from tasks import publish
 
 
-class TestPublishOld():
+class TestPublish():
     @mock_s3
     def test_it_is_callable(self, monkeypatch):
         monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake-access-key')
         monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake-secret-key')
-        
+
         ctx = MockContext()
 
         aws_region = 'region'
@@ -21,9 +21,9 @@ class TestPublishOld():
         conn = boto3.resource('s3', region_name=aws_region)
 
         # We need to create the bucket since this is all in
-        # Moto's 'virtual' AWS account
+        # Boto's 'virtual' AWS account
         conn.create_bucket(Bucket=bucket)
 
         publish(ctx, base_url='/site/prefix', site_prefix='site/prefix',
                 bucket=bucket, cache_control='max-age: boop',
-                aws_region=aws_region, dry_run=True)
+                aws_region=aws_region, dry_run=False)


### PR DESCRIPTION
This PR fills out tests for `publish`, `build`, and `common` tasks.

I worked a bit with @cmc333333 to come up with the strategy for `monkeypatch`ing the common `Path` constants for various working directories, which represents a lot of the refactoring changes in the task functions.