### PR TITLE
Use string instead of Path for `directory` publish task

### DIFF
--- a/tasks/publish.py
+++ b/tasks/publish.py
@@ -5,6 +5,7 @@ import os
 
 from datetime import datetime
 
+import boto3
 from invoke import task
 
 from publishing import s3publisher
@@ -32,15 +33,19 @@ def publish(ctx, base_url, site_prefix, bucket, cache_control,
 
     start_time = datetime.now()
 
+    s3_client = boto3.client(
+        service_name='s3',
+        region_name=aws_region,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key)
+
     s3publisher.publish_to_s3(
         directory=str(SITE_BUILD_DIR_PATH),
         base_url=base_url,
         site_prefix=site_prefix,
         bucket=bucket,
         cache_control=cache_control,
-        aws_region=aws_region,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
+        s3_client=s3_client,
         dry_run=dry_run
     )
 

--- a/tasks/publish.py
+++ b/tasks/publish.py
@@ -7,7 +7,8 @@ from datetime import datetime
 
 from invoke import task
 
-from publishing.s3publisher import publish_to_s3
+from publishing import s3publisher
+
 from log_utils import get_logger
 from .common import SITE_BUILD_DIR_PATH, delta_to_mins_secs
 
@@ -31,8 +32,8 @@ def publish(ctx, base_url, site_prefix, bucket, cache_control,
 
     start_time = datetime.now()
 
-    publish_to_s3(
-        directory=SITE_BUILD_DIR_PATH,
+    s3publisher.publish_to_s3(
+        directory=str(SITE_BUILD_DIR_PATH),
         base_url=base_url,
         site_prefix=site_prefix,
         bucket=bucket,

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1,29 +1,56 @@
 import boto3
+import pytest
+
+from unittest.mock import Mock
 
 from moto import mock_s3
-
 from invoke import MockContext
 
 from tasks import publish
+from tasks.common import SITE_BUILD_DIR_PATH
+
+TEST_BUCKET = 'test-bucket'
+TEST_REGION = 'test-region'
+
+
+@pytest.fixture
+def s3_conn(monkeypatch):
+    with mock_s3():
+        monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake-access-key')
+        monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake-secret-key')
+        conn = boto3.resource('s3', region_name=TEST_BUCKET)
+        conn.create_bucket(Bucket=TEST_BUCKET)
+        yield conn
 
 
 class TestPublish():
-    @mock_s3
-    def test_it_is_callable(self, monkeypatch):
-        monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fake-access-key')
-        monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fake-secret-key')
+    def test_it_is_callable(self, s3_conn):
+        ctx = MockContext()
+
+        publish(ctx, base_url='/site/prefix', site_prefix='site/prefix',
+                bucket=TEST_BUCKET, cache_control='max-age: boop',
+                aws_region=TEST_REGION)
+
+    def test_it_calls_publish_to_s3(self, monkeypatch, s3_conn):
+        mock_publish_to_s3 = Mock()
+        monkeypatch.setattr('publishing.s3publisher.publish_to_s3',
+                            mock_publish_to_s3)
 
         ctx = MockContext()
 
-        aws_region = 'region'
-        bucket = 'bucket'
+        kwargs = dict(
+            base_url='/site/prefix',
+            site_prefix='site/prefix',
+            bucket=TEST_BUCKET,
+            cache_control='max-age: boop',
+            aws_region=TEST_REGION,
+        )
 
-        conn = boto3.resource('s3', region_name=aws_region)
+        publish(ctx, **kwargs)
 
-        # We need to create the bucket since this is all in
-        # Moto's 'virtual' AWS account
-        conn.create_bucket(Bucket=bucket)
+        mock_publish_to_s3.assert_called_once()
 
-        publish(ctx, base_url='/site/prefix', site_prefix='site/prefix',
-                bucket=bucket, cache_control='max-age: boop',
-                aws_region=aws_region, dry_run=False)
+        # check that the `directory` kwarg is a string, not a Path
+        _, actual_kwargs = mock_publish_to_s3.call_args_list[0]
+        assert type(actual_kwargs['directory']) == str
+        assert actual_kwargs['directory'] == str(SITE_BUILD_DIR_PATH)


### PR DESCRIPTION
Also add a test to make sure it is called with the proper argument.

This is a bit wonky of a test but it should prevent the bug in #123 from happening easily again.