### PR TITLE
Disable document generation when installing Jekyll

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -186,7 +186,7 @@ def build_jekyll(ctx, branch, owner, repository, site_prefix,
 
         else:
             LOGGER.info('Installing Jekyll')
-            ctx.run('gem install jekyll')
+            ctx.run('gem install jekyll --no-document')
 
         jekyll_vers_res = ctx.run(f'{jekyll_cmd} -v')
         LOGGER.info(f'Building using Jekyll version: {jekyll_vers_res.stdout}')

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -229,7 +229,7 @@ def build_hugo(ctx, branch, owner, repository, site_prefix,
     '''
     Builds the cloned site with Hugo
     '''
-    # Note that no pre- or post-tasks will be called when calling
+    # Note that no pre/post-tasks will be called when calling
     # the download_hugo task this way
     download_hugo(ctx, hugo_version)
 

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -29,7 +29,6 @@ RUBY_VERSION = '.ruby-version'
 GEMFILE = 'Gemfile'
 JEKYLL_CONFIG_YML = '_config.yml'
 
-
 def has_federalist_script():
     '''
     Checks for existence of the "federalist" script in the

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -29,6 +29,7 @@ RUBY_VERSION = '.ruby-version'
 GEMFILE = 'Gemfile'
 JEKYLL_CONFIG_YML = '_config.yml'
 
+
 def has_federalist_script():
     '''
     Checks for existence of the "federalist" script in the


### PR DESCRIPTION
Might shave a second off the build time? Since this documentation isn't accessible to anyone, I think it's safe to skip installing it.

http://guides.rubygems.org/command-reference/#gem-install

Currently in the build logs:
```
Parsing documentation for public_suffix-3.0.2
Installing ri documentation for public_suffix-3.0.2
Parsing documentation for addressable-2.5.2
Installing ri documentation for addressable-2.5.2
Parsing documentation for colorator-1.1.0
Installing ri documentation for colorator-1.1.0
Parsing documentation for http_parser.rb-0.6.0
Installing ri documentation for http_parser.rb-0.6.0
Parsing documentation for eventmachine-1.2.5
Installing ri documentation for eventmachine-1.2.5
Parsing documentation for em-websocket-0.5.1
Installing ri documentation for em-websocket-0.5.1
Parsing documentation for concurrent-ruby-1.0.5
Installing ri documentation for concurrent-ruby-1.0.5
Parsing documentation for i18n-0.9.5
Installing ri documentation for i18n-0.9.5
Parsing documentation for rb-fsevent-0.10.3
Installing ri documentation for rb-fsevent-0.10.3
Parsing documentation for ffi-1.9.23
Installing ri documentation for ffi-1.9.23
Parsing documentation for rb-inotify-0.9.10
Installing ri documentation for rb-inotify-0.9.10
Parsing documentation for sass-listen-4.0.0
Installing ri documentation for sass-listen-4.0.0
Parsing documentation for sass-3.5.5
Installing ri documentation for sass-3.5.5
Parsing documentation for jekyll-sass-converter-1.5.2
Installing ri documentation for jekyll-sass-converter-1.5.2
Parsing documentation for ruby_dep-1.5.0
Installing ri documentation for ruby_dep-1.5.0
Parsing documentation for listen-3.1.5
Installing ri documentation for listen-3.1.5
Parsing documentation for jekyll-watch-2.0.0
Installing ri documentation for jekyll-watch-2.0.0
Parsing documentation for kramdown-1.16.2
Installing ri documentation for kramdown-1.16.2
Parsing documentation for liquid-4.0.0
Installing ri documentation for liquid-4.0.0
Parsing documentation for mercenary-0.3.6
Installing ri documentation for mercenary-0.3.6
Parsing documentation for forwardable-extended-2.6.0
Installing ri documentation for forwardable-extended-2.6.0
Parsing documentation for pathutil-0.16.1
Installing ri documentation for pathutil-0.16.1
Parsing documentation for rouge-3.1.1
Installing ri documentation for rouge-3.1.1
Parsing documentation for safe_yaml-1.0.4
Installing ri documentation for safe_yaml-1.0.4
Parsing documentation for jekyll-3.7.3
Installing ri documentation for jekyll-3.7.3
Done installing documentation for public_suffix, addressable, colorator, http_parser.rb, eventmachine, em-websocket, concurrent-ruby, i18n, rb-fsevent, ffi, rb-inotify, sass-listen, sass, jekyll-sass-converter, ruby_dep, listen, jekyll-watch, kramdown, liquid, mercenary, forwardable-extended, pathutil, rouge, safe_yaml, jekyll after 43 seconds
```