### PR TITLE
WIP: Quick design refresh for default 404 page

### DIFF
--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -91,15 +91,61 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, cache_control,
     # Add local 404 if does not already exist
     filename_404 = directory + '/404/index.html'
     if not path.isfile(filename_404):
-        msg_404 = []
-        msg_404.append("<html><body><h1>404 Error: Page not found</h1>")
-        msg_404.append("<p>We could not find the page you were looking for.")
-        msg_404.append(" Return to the <a href='/'>homepage<a/>?</p>")
-        msg_404.append("<p>This is a default 404 page for")
-        msg_404.append(" <a href='https://federalist.18f.gov'>Federalist</a>,")
-        msg_404.append(" a hosting service for federal websites.")
-        msg_404.append("</p></body></html>")
-        msg_404 = ''.join(msg_404)
+        msg_404 = """
+        <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <style>
+                    span#title {
+                        font-size: 40px;
+                        padding-bottom: 2px;
+                        border-bottom: 3px solid #205493;
+                    }
+                    #federalist-explanation {
+                        font-style: italic;
+                    }
+                    body {
+                        font-family: "Merriweather", "Georgia", "Cambria", "Times New Roman", "Times", serif;
+                    }
+                    #content {
+                        margin: 12% auto;
+                    }
+                    @media (min-width: 1025px) {
+                        #content {
+                            width: 60%;
+                        }
+                    }
+                    @media (max-width: 1025px) {
+                        #content {
+                            width: 75%;
+                        }
+                    }
+                    p {
+                        font-size: 1.25em;
+                        margin: 50px 0 40px 0;
+                    }
+                </style>
+            </head>
+            <body>
+                <div id="content">
+                    <h1>
+                        <span id="title">404 / Page not found</span>
+                    </h1>
+                    <p>
+                        You might want to double-check your link and try again, or return to the <a href='/'>homepage<a/>.
+                    </p>
+                    <p id="federalist-explanation">
+                        This is a default 404 page for <a href='https://federalist.18f.gov'>Federalist</a>, a hosting service for federal websites.
+                    </p>
+                    <img id="federalist-logo"
+                         height="30"
+                         src="https://federalist.18f.gov/assets/images/federalist-logo.png"
+                         alt="Federalist logo, quill inside a circle."
+                </div>
+            </body>
+        </html>
+        """
+
         makedirs(path.dirname(filename_404), exist_ok=True)
         with open(filename_404, "w+") as f:
             f.write(msg_404)


### PR DESCRIPTION
# Design goals

Create a 404 page that references the Federalist brand, but feels neutral enough not to clash radically with the custom design systems of clients using Federalist. 

I decided to keep the existing white background because bold colors could clash with client color systems. Incorporated Federalist fonts and logo.

# Screenshots 

### Chrome, laptop
<img width="1277" alt="404-chrome-laptop" src="https://user-images.githubusercontent.com/3209501/51924297-6197cd00-23b2-11e9-886e-5f0a4ebad07e.png">

###  Chrome, Galaxy S5
<img width="370" alt="404-chrome-galaxy" src="https://user-images.githubusercontent.com/3209501/51924351-7bd1ab00-23b2-11e9-9e6c-454a619cc8f9.png">

### Chrome, iPhone 5
<img width="372" alt="404-chrome-iphone-5" src="https://user-images.githubusercontent.com/3209501/51924422-9efc5a80-23b2-11e9-97e4-67b7e4dbad57.png">

### Other browsers 
I checked the design on Firefox and Safari as well as Chrome. 

Have not yet checked on Internet Explorer. 

# TODOs

+ [ ] **Test on Internet Explorer.**
+ [ ] **Test by publishing to a real S3 bucket.**  I've been developing locally by creating a local `404.html`. To test the full deploy path, I could either use a personal AWS bucket or a sandbox Federalist/Cloud Foundry account. @amirbey or @jmhooper, suggestions on the best way to test?

# Issue

https://github.com/18F/federalist/issues/2098

# Disclaimer 

I'm not a specialist in design or in front-end dev ... but I do enjoy dabbling!

So please feel very free to suggest improvements, corrections, or share tips! 🙇 