### PR TITLE
Remove misleading 404-related code in s3publisher

### DIFF
--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -4,7 +4,7 @@ Classes and methods for publishing a directory to S3
 
 import glob
 
-from os import path, makedirs
+from os import path
 from datetime import datetime
 
 from log_utils import get_logger
@@ -87,28 +87,6 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, cache_control,
                                  site_prefix=site_prefix,
                                  cache_control=cache_control)
             local_files.append(site_file)
-
-    # Add local 404 if does not already exist
-    filename_404 = directory + '/404/index.html'
-    if not path.isfile(filename_404):
-        msg_404 = []
-        msg_404.append("<html><body><h1>404 Error: Page not found</h1>")
-        msg_404.append("<p>We could not find the page you were looking for.")
-        msg_404.append(" Return to the <a href='/'>homepage<a/>?</p>")
-        msg_404.append("<p>This is a default 404 page for")
-        msg_404.append(" <a href='https://federalist.18f.gov'>Federalist</a>,")
-        msg_404.append(" a hosting service for federal websites.")
-        msg_404.append("</p></body></html>")
-        msg_404 = ''.join(msg_404)
-        makedirs(path.dirname(filename_404), exist_ok=True)
-        with open(filename_404, "w+") as f:
-            f.write(msg_404)
-
-        file_404 = SiteFile(filename=filename_404,
-                            dir_prefix=directory,
-                            site_prefix=site_prefix,
-                            cache_control=cache_control)
-        local_files.append(file_404)
 
     # Create a list of redirects from the local files
     local_redirects = []


### PR DESCRIPTION
# Why? 

This deleted block of code makes it look like `s3publisher` is responsible for setting up the 404 page. 

But that's not the case. The default 404 page for Federalist client sites is set this way:

_https://github.com/18F/federalist-404-page#deployment_

# Disclaimer 

I haven't exercised this code myself yet. This change should be tested before it's deployed, to make sure it has no effect on users. Removing this code should have no effect on user experience. 

The only testing/linting I've done is run `flake8` and correct 1 reported issue.