### PR TITLE
Add 404 when not present in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: Bandit
           command: |
-            docker-compose -f docker-compose.test.yml run app bandit -r .
+            docker-compose -f docker-compose.test.yml run app bandit publishing/*.py tasks/*.py log_utils/*.py
 
       - run:
           name: Install cc-test-reporter
@@ -48,13 +48,12 @@ jobs:
           name: CodeClimate after-build
           command: |
             # for whatever reason the current user doesn't have access
-            # to the directory that gets created for the docker-compose 
+            # to the directory that gets created for the docker-compose
             # `coverage/` volume, so `chown` it
             sudo chown -R $(whoami) ./coverage
             ./cc-test-reporter format-coverage -t coverage.py ./coverage/coverage.xml
             ./cc-test-reporter upload-coverage || true
-      
+
       - store_artifacts:
           path: ./coverage/coverage.xml
 
-        

--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -90,7 +90,7 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, cache_control,
             local_files.append(site_file)
 
     # Add local 404 if does not already exist
-    filename_404 = directory + '/404/index.html'
+    filename_404 = directory + '/404.html'
     default_404_url = ('https://raw.githubusercontent.com'
                        '/18F/federalist-404-page/master/'
                        '404-federalist-client.html')

--- a/publishing/s3publisher.py
+++ b/publishing/s3publisher.py
@@ -3,8 +3,9 @@ Classes and methods for publishing a directory to S3
 '''
 
 import glob
+import requests
 
-from os import path
+from os import path, makedirs
 from datetime import datetime
 
 from log_utils import get_logger
@@ -87,6 +88,23 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, cache_control,
                                  site_prefix=site_prefix,
                                  cache_control=cache_control)
             local_files.append(site_file)
+
+    # Add local 404 if does not already exist
+    filename_404 = directory + '/404/index.html'
+    default_404_url = ('https://raw.githubusercontent.com'
+                       '/18F/federalist-404-page/master/'
+                       '404-federalist-client.html')
+    if not path.isfile(filename_404):
+        default_404 = requests.get(default_404_url)
+        makedirs(path.dirname(filename_404), exist_ok=True)
+        with open(filename_404, "w+") as f:
+            f.write(default_404.text)
+
+        file_404 = SiteFile(filename=filename_404,
+                            dir_prefix=directory,
+                            site_prefix=site_prefix,
+                            cache_control=cache_control)
+        local_files.append(file_404)
 
     # Create a list of redirects from the local files
     local_redirects = []

--- a/tasks/clone.py
+++ b/tasks/clone.py
@@ -14,7 +14,7 @@ from .common import (REPO_BASE_URL, CLONE_DIR_PATH,
 LOGGER = get_logger('CLONE')
 
 
-def clone_url(owner, repository, access_token=''):
+def clone_url(owner, repository, access_token=''):  # nosec
     '''
     Creates a URL to a remote git repository.
     If `access_token` is specified, it will be included in the authentication

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -105,7 +105,7 @@ def test_publish_to_s3(tmpdir, s3_client):
 
         keys = [r['Key'] for r in results['Contents']]
 
-        assert results['KeyCount'] == 6  # 4 files, 3 redirect objects w/ /404.html
+        assert results['KeyCount'] == 6  # 4 files, 3 redirects & 404.html
 
         assert f'{site_prefix}/index.html' in keys
         assert f'{site_prefix}/boop.txt' in keys

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -105,14 +105,13 @@ def test_publish_to_s3(tmpdir, s3_client):
 
         keys = [r['Key'] for r in results['Contents']]
 
-        assert results['KeyCount'] == 7  # 4 files, 3 redirect objects w/ /404/
+        assert results['KeyCount'] == 6  # 4 files, 3 redirect objects w/ /404.html
 
         assert f'{site_prefix}/index.html' in keys
         assert f'{site_prefix}/boop.txt' in keys
         assert f'{site_prefix}/sub_dir' in keys
         assert f'{site_prefix}/sub_dir/index.html' in keys
-        assert f'{site_prefix}/404' in keys
-        assert f'{site_prefix}/404/index.html' in keys
+        assert f'{site_prefix}/404.html' in keys
         assert f'{site_prefix}' in keys  # main redirect object
 
         # Add another file to the directory
@@ -121,7 +120,7 @@ def test_publish_to_s3(tmpdir, s3_client):
         publish_to_s3(**publish_kwargs)
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
 
-        assert results['KeyCount'] == 8
+        assert results['KeyCount'] == 7
 
         # Delete some files and check that the published files count
         # is correct
@@ -129,7 +128,7 @@ def test_publish_to_s3(tmpdir, s3_client):
         test_dir.join('boop.txt').remove()
         publish_to_s3(**publish_kwargs)
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
-        assert results['KeyCount'] == 6
+        assert results['KeyCount'] == 5
 
         # Write an existing file with different content so that it
         # needs to get updated
@@ -142,7 +141,7 @@ def test_publish_to_s3(tmpdir, s3_client):
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
 
         # number of keys should be the same
-        assert results['KeyCount'] == 6
+        assert results['KeyCount'] == 5
 
         # make sure content in changed file is updated
         new_etag = s3_client.get_object(

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -1,5 +1,6 @@
 import boto3
 import pytest
+import requests_mock
 
 from moto import mock_s3
 
@@ -90,47 +91,61 @@ def test_publish_to_s3(tmpdir, s3_client):
         'cache_control': 'max-age=10',
         's3_client': s3_client,
     }
-    publish_to_s3(**publish_kwargs)
 
-    results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+    # Create mock for default 404 page request
+    with requests_mock.mock() as m:
+        m.get(('https://raw.githubusercontent.com'
+               '/18F/federalist-404-page/master/'
+               '404-federalist-client.html'),
+              text='default 404 page')
 
-    keys = [r['Key'] for r in results['Contents']]
+        publish_to_s3(**publish_kwargs)
 
-    assert results['KeyCount'] == 5  # 4 files, 3 redirect objects
+        results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
 
-    assert f'{site_prefix}/index.html' in keys
-    assert f'{site_prefix}/boop.txt' in keys
-    assert f'{site_prefix}/sub_dir' in keys
-    assert f'{site_prefix}/sub_dir/index.html' in keys
-    assert f'{site_prefix}' in keys  # main redirect object
+        keys = [r['Key'] for r in results['Contents']]
 
-    # Add another file to the directory
-    more_filenames = ['new_index.html']
-    _make_fake_files(test_dir, more_filenames)
-    publish_to_s3(**publish_kwargs)
-    results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+        assert results['KeyCount'] == 7  # 4 files, 3 redirect objects w/ /404/
 
-    assert results['KeyCount'] == 6
+        assert f'{site_prefix}/index.html' in keys
+        assert f'{site_prefix}/boop.txt' in keys
+        assert f'{site_prefix}/sub_dir' in keys
+        assert f'{site_prefix}/sub_dir/index.html' in keys
+        assert f'{site_prefix}/404' in keys
+        assert f'{site_prefix}/404/index.html' in keys
+        assert f'{site_prefix}' in keys  # main redirect object
 
-    # Delete some files and check that the published files count
-    # is correct
-    test_dir.join('new_index.html').remove()
-    test_dir.join('boop.txt').remove()
-    publish_to_s3(**publish_kwargs)
-    results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
-    assert results['KeyCount'] == 4
+        # Add another file to the directory
+        more_filenames = ['new_index.html']
+        _make_fake_files(test_dir, more_filenames)
+        publish_to_s3(**publish_kwargs)
+        results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
 
-    # Write an existing file with different content so that it
-    # needs to get updated
-    index_key = f'{site_prefix}/index.html'
-    orig_etag = s3_client.get_object(Bucket=TEST_BUCKET, Key=index_key)['ETag']
-    test_dir.join('index.html').write('totally new content!!!')
-    publish_to_s3(**publish_kwargs)
-    results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+        assert results['KeyCount'] == 8
 
-    # number of keys should be the same
-    assert results['KeyCount'] == 4
+        # Delete some files and check that the published files count
+        # is correct
+        test_dir.join('new_index.html').remove()
+        test_dir.join('boop.txt').remove()
+        publish_to_s3(**publish_kwargs)
+        results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+        assert results['KeyCount'] == 6
 
-    # make sure content in changed file is updated
-    new_etag = s3_client.get_object(Bucket=TEST_BUCKET, Key=index_key)['ETag']
-    assert new_etag != orig_etag
+        # Write an existing file with different content so that it
+        # needs to get updated
+        index_key = f'{site_prefix}/index.html'
+        orig_etag = s3_client.get_object(
+                        Bucket=TEST_BUCKET,
+                        Key=index_key)['ETag']
+        test_dir.join('index.html').write('totally new content!!!')
+        publish_to_s3(**publish_kwargs)
+        results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+
+        # number of keys should be the same
+        assert results['KeyCount'] == 6
+
+        # make sure content in changed file is updated
+        new_etag = s3_client.get_object(
+                    Bucket=TEST_BUCKET,
+                    Key=index_key)['ETag']
+        assert new_etag != orig_etag

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1,5 +1,6 @@
 import boto3
 import pytest
+import requests_mock
 
 from unittest.mock import Mock
 
@@ -27,9 +28,16 @@ class TestPublish():
     def test_it_is_callable(self, s3_conn):
         ctx = MockContext()
 
-        publish(ctx, base_url='/site/prefix', site_prefix='site/prefix',
-                bucket=TEST_BUCKET, cache_control='max-age: boop',
-                aws_region=TEST_REGION)
+        # Create mock for default 404 page request
+        with requests_mock.mock() as m:
+            m.get(('https://raw.githubusercontent.com'
+                   '/18F/federalist-404-page/master/'
+                   '404-federalist-client.html'),
+                  text='default 404 page')
+
+            publish(ctx, base_url='/site/prefix', site_prefix='site/prefix',
+                    bucket=TEST_BUCKET, cache_control='max-age: boop',
+                    aws_region=TEST_REGION)
 
     def test_it_calls_publish_to_s3(self, monkeypatch, s3_conn):
         mock_publish_to_s3 = Mock()


### PR DESCRIPTION
## Description

Add `404/index.html` to the site directories on build if it does not already exist.  Based off of the [previous implementation](https://github.com/18F/federalist-garden-build/commit/8ee5acfee3db2df1965e55df96a87e11824d1781#diff-38514dbf1109a31b73df2991019686b5). 

closes #169 