### PR TITLE
Disable Gatsby telemetry and npm audit in builds

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -80,6 +80,7 @@ def setup_node(ctx):
             if PACKAGE_JSON_PATH.is_file():
                 LOGGER.info('Installing production dependencies '
                             'in package.json')
+                ctx.run(f'{npm_command} set audit false')
                 ctx.run(f'{npm_command} install --production')
 
 
@@ -118,6 +119,7 @@ def build_env(branch, owner, repository, site_prefix, base_url):
         'BASEURL': base_url,
         # necessary to make sure build engines use utf-8 encoding
         'LANG': 'en_US.UTF-8',
+        'GATSBY_TELEMETRY_DISABLED': '1',
     }
 
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -47,6 +47,7 @@ class TestSetupNode():
         ctx = MockContext(run={
             'node --version': Result(),
             'npm --version': Result(),
+            'npm set audit false': Result(),
             'npm install --production': Result(),
         })
         tasks.setup_node(ctx)
@@ -177,7 +178,8 @@ class TestBuildJekyll():
                                  'SITE_PREFIX': 'site/prefix',
                                  'BASEURL': '/site/prefix',
                                  'LANG': 'en_US.UTF-8',
-                                 'JEKYLL_ENV': 'production'}
+                                 'JEKYLL_ENV': 'production',
+                                 'GATSBY_TELEMETRY_DISABLED': '1'}
 
         # Check that the config file has had baseurl, branch, and custom
         # config added


### PR DESCRIPTION
Just some cleanup I notices when running.