### PR TITLE
Configure logging globally

### DIFF
--- a/tasks/build.py
+++ b/tasks/build.py
@@ -66,11 +66,9 @@ def setup_node(ctx):
                 npm_command = f'nvm use && {npm_command}'
             else:
                 # output node and npm versions if the defaults are used
-                node_version_res = ctx.run(f'node --version', hide=True)
-                print(f'Node version: {node_version_res.stdout}')
-                npm_version_res = ctx.run(f'{npm_command} --version',
-                                          hide=True)
-                print(f'NPM version: {npm_version_res.stdout}')
+                ctx.run(f'echo Node version: $(node --version)')
+                result = ctx.run(f'echo NPM version: $({npm_command} --version)')
+                print(result)
 
             PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON
             if PACKAGE_JSON_PATH.is_file():
@@ -151,10 +149,10 @@ def setup_ruby(ctx):
                 ruby_version = shlex.quote(ruby_version)
             if ruby_version:
                 print('Using ruby version in .ruby-version')
-                ctx.run(f'rvm install {ruby_version}')
+                result = ctx.run(f'rvm install {ruby_version}')
+                print(result)
 
-        ruby_ver_res = ctx.run('ruby -v')
-        print(f'Ruby version: {ruby_ver_res.stdout}')
+        ctx.run('echo Ruby version: $(ruby -v)')
 
 
 @task
@@ -215,8 +213,7 @@ def build_jekyll(ctx, branch, owner, repository, site_prefix,
             print('Installing Jekyll')
             ctx.run('gem install jekyll --no-document')
 
-        jekyll_vers_res = ctx.run(f'{jekyll_cmd} -v')
-        print(f'Building using Jekyll version: {jekyll_vers_res.stdout}')
+        ctx.run(f'echo Building using Jekyll version: $({jekyll_cmd} -v)')
 
         jekyll_build_env = build_env(branch, owner, repository, site_prefix,
                                      base_url)
@@ -294,8 +291,7 @@ def build_hugo(ctx, branch, owner, repository, site_prefix,
 
     HUGO_BIN_PATH = WORKING_DIR_PATH / HUGO_BIN
 
-    hugo_vers_res = ctx.run(f'{HUGO_BIN_PATH} version')
-    print(f'hugo version: {hugo_vers_res.stdout}')
+    ctx.run(f'echo hugo version: $({HUGO_BIN_PATH} version)')
     print('Building site with hugo')
 
     with node_context(ctx):  # in case some hugo plugin needs node

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -66,7 +66,7 @@ def setup_node(ctx):
                 npm_command = f'nvm use && {npm_command}'
             else:
                 # output node and npm versions if the defaults are used
-                ctx.run(f'echo Node version: $(node --version)')
+                ctx.run('echo Node version: $(node --version)')
                 ctx.run(f'echo NPM version: $({npm_command} --version)')
 
             PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -67,8 +67,7 @@ def setup_node(ctx):
             else:
                 # output node and npm versions if the defaults are used
                 ctx.run(f'echo Node version: $(node --version)')
-                result = ctx.run(f'echo NPM version: $({npm_command} --version)')
-                print(result)
+                ctx.run(f'echo NPM version: $({npm_command} --version)')
 
             PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON
             if PACKAGE_JSON_PATH.is_file():
@@ -149,8 +148,7 @@ def setup_ruby(ctx):
                 ruby_version = shlex.quote(ruby_version)
             if ruby_version:
                 print('Using ruby version in .ruby-version')
-                result = ctx.run(f'rvm install {ruby_version}')
-                print(result)
+                ctx.run(f'rvm install {ruby_version}')
 
         ctx.run('echo Ruby version: $(ruby -v)')
 

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -39,8 +39,8 @@ def run_task(ctx, task_name, log_attrs={}, flags_dict=None, env=None):
         run_kwargs['env'] = env
 
     logger = get_logger(task_name, log_attrs)
-    run_kwargs['out_stream'] = StreamToLogger(logger)
-    run_kwargs['err_stream'] = StreamToLogger(logger, logging.ERROR)
+    ctx.config.run.out_stream = StreamToLogger(logger)
+    ctx.config.run.err_stream = StreamToLogger(logger, logging.ERROR)
 
     ctx.run(command, **run_kwargs)
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -45,8 +45,8 @@ class TestSetupNode():
     def test_installs_production_deps(self, patch_clone_dir):
         create_file(patch_clone_dir / PACKAGE_JSON)
         ctx = MockContext(run={
-            'node --version': Result(),
-            'npm --version': Result(),
+            'echo Node version: $(node --version)': Result(),
+            'echo NPM version: $(npm --version)': Result(),
             'npm set audit false': Result(),
             'npm install --production': Result(),
         })
@@ -102,7 +102,7 @@ class TestRunFederalistScript():
 class TestSetupRuby():
     def test_it_is_callable(self):
         ctx = MockContext(run={
-            'ruby -v': Result(),
+            'echo Ruby version: $(ruby -v)': Result(),
         })
         tasks.setup_ruby(ctx)
 
@@ -110,7 +110,7 @@ class TestSetupRuby():
         create_file(patch_clone_dir / RUBY_VERSION, '2.3')
         ctx = MockContext(run={
             'rvm install 2.3': Result(),
-            'ruby -v': Result(),
+            'echo Ruby version: $(ruby -v)': Result(),
         })
         tasks.setup_ruby(ctx)
 
@@ -118,7 +118,7 @@ class TestSetupRuby():
         create_file(patch_clone_dir / RUBY_VERSION, '  $2.2  ')
         ctx = MockContext(run={
             "rvm install '$2.2'": Result(),
-            'ruby -v': Result(),
+            'echo Ruby version: $(ruby -v)': Result(),
         })
         tasks.setup_ruby(ctx)
 
@@ -193,7 +193,7 @@ class TestBuildJekyll():
         ctx = MockContext(run={
             'gem install bundler --version "<2"': Result(),
             'bundle install': Result(),
-            'bundle exec jekyll -v': Result(),
+            'echo Building using Jekyll version: $(bundle exec jekyll -v)': Result(),
             f'bundle exec jekyll build --destination /boop': Result(),
         })
         tasks.build_jekyll(ctx, branch='branch', owner='owner',
@@ -291,7 +291,7 @@ class TestBuildHugo():
         hugo_call = (f'{hugo_path} --source /work/site_repo '
                      f'--destination /work/site_repo/_site')
         ctx = MockContext(run={
-            f'{hugo_path} version': Result(),
+            f'echo hugo version: $({hugo_path} version)': Result(),
             hugo_call: Result(),
         })
         with requests_mock.Mocker() as m:
@@ -306,7 +306,7 @@ class TestBuildHugo():
             kwargs['base_url'] = '/test_base'
             hugo_call += f' --baseURL /test_base'
             ctx = MockContext(run={
-                f'{hugo_path} version': Result(),
+                f'echo hugo version: $({hugo_path} version)': Result(),
                 hugo_call: Result(),
             })
             tasks.build_hugo(ctx, **kwargs)

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -193,7 +193,8 @@ class TestBuildJekyll():
         ctx = MockContext(run={
             'gem install bundler --version "<2"': Result(),
             'bundle install': Result(),
-            'echo Building using Jekyll version: $(bundle exec jekyll -v)': Result(),
+            'echo Building using Jekyll version: '
+            '$(bundle exec jekyll -v)': Result(),
             f'bundle exec jekyll build --destination /boop': Result(),
         })
         tasks.build_jekyll(ctx, branch='branch', owner='owner',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -34,5 +34,3 @@ def test_run_task(monkeypatch):
     assert call_args[0] == (
         'inv fake-task fake-flag=flag-val other-flag=other-val',)
     assert call_args[1]['env'] == env
-    assert call_args[1]['out_stream']
-    assert call_args[1]['err_stream']


### PR DESCRIPTION
The previous configuration did not capture stdout and stderr for subtasks, lets make sure those are included. Also refactored a view log messages that can just go to stdout.