### PR TITLE
Clone the whole repo when pushing to an empty repo from a template

### DIFF
--- a/tasks/main.py
+++ b/tasks/main.py
@@ -140,7 +140,6 @@ def main():
                     '--owner': SOURCE_OWNER,
                     '--repository': SOURCE_REPO,
                     '--branch': BRANCH,
-                    '--depth': '--depth 1',
                 }
 
                 run('clone-repo', clone_source_flags, clone_env)


### PR DESCRIPTION
Ugh, cloning from a template is not working, apparently we have to clone the whole history when pushing to a fresh repo.