### PR TITLE
Improve support for running builds as tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,12 @@ jobs:
       - run:
           name: Tag docker image as latest for registry
           command: |
-            docker tag federalist-garden-build localhost:5000/federalist-garden-build-test
+            docker tag federalist-garden-build localhost:5000/federalist-garden-build
       
       - run:
           name: Push docker image to registry
           command: |
-            docker push localhost:5000/federalist-garden-build-test
+            docker push localhost:5000/federalist-garden-build
       
   deploy-production:
     machine: true

--- a/bin/push-docker-image.sh
+++ b/bin/push-docker-image.sh
@@ -2,6 +2,6 @@
 set -eo pipefail
 
 # Make sure local registry is running on localhost:5000
-docker build --no-cache --tag federalist-garden-build .
-docker tag federalist-garden-build localhost:5000/federalist-garden-build
-docker push localhost:5000/federalist-garden-build
+docker build --tag federalist-garden-build-dev .
+docker tag federalist-garden-build-dev localhost:5000/federalist-garden-build-dev
+docker push localhost:5000/federalist-garden-build-dev

--- a/bin/push-docker-image.sh
+++ b/bin/push-docker-image.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
+# federalist-garden-build-dev-task
+TAG=$1
+
 # Make sure local registry is running on localhost:5000
-docker build --tag federalist-garden-build-dev .
-docker tag federalist-garden-build-dev localhost:5000/federalist-garden-build-dev
-docker push localhost:5000/federalist-garden-build-dev
+docker build --tag $TAG .
+docker tag $TAG localhost:5000/$TAG
+docker push localhost:5000/$TAG

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import getopt
 import os
 from pathlib import Path
 import sys
@@ -31,7 +30,7 @@ if __name__ == "__main__":
                             metavar="'{\"foo\": \"bar\"}'")
         args = parser.parse_args()
         params = json.loads(args.params)
-        for k,v in params.items():
+        for k, v in params.items():
             os.environ[k] = v
 
     else:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import argparse
+import json
 import getopt
 import os
 from pathlib import Path
@@ -21,43 +23,16 @@ def load_env():
         load_dotenv(DOTENV_PATH)
 
 
-flags = {
-    'aws-access-key': 'AWS_ACCESS_KEY_ID',
-    'aws-region': 'AWS_DEFAULT_REGION',
-    'aws-secret-access-key': 'AWS_SECRET_ACCESS_KEY',
-    'baseurl': 'BASEURL',
-    'branch': 'BRANCH',
-    'bucket': 'BUCKET',
-    'build-id': 'BUILD_ID',
-    'builder-callback': 'FEDERALIST_BUILDER_CALLBACK',
-    'cache-control': 'CACHE_CONTROL',
-    'config': 'CONFIG',
-    'generator': 'GENERATOR',
-    'github-token': 'GITHUB_TOKEN',
-    'owner': 'OWNER',
-    'repo': 'REPOSITORY',
-    'site-prefix': 'SITE_PREFIX',
-    'source-repo': 'SOURCE_REPO',
-    'source-owner': 'SOURCE_OWNER',
-    'status-callback': 'STATUS_CALLBACK',
-    'skip-logging': 'SKIP_LOGGING'
-}
-
-
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        print('Using command line arguments')
-        try:
-            short_opts = ':'.join(list(flags.keys())) + ':'
-            opts, args = getopt.getopt(sys.argv[1:], short_opts)
-        except getopt.GetoptError as err:
-            print(err)
-            print("Arguments:\n")
-            print(flags)
-            sys.exit(2)
-        for opt, arg in opts:
-            name = flags[opt[1:]]
-            os.environ[name] = arg
+        parser = argparse.ArgumentParser(description='Run a federalist build')
+        parser.add_argument('-p', '--params', dest='params', required=True,
+                            help='A JSON encoded string',
+                            metavar="'{\"foo\": \"bar\"}'")
+        args = parser.parse_args()
+        params = json.loads(args.params)
+        for k,v in params.items():
+            os.environ[k] = v
 
     else:
         load_env()

--- a/manifests/dev/manifest.yml
+++ b/manifests/dev/manifest.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   memory: 1G
   disk_quota: 2G
   docker:
-    image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev
+    image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build
   services:
     - federalist-dev-rds
   command: bash ./run.sh

--- a/manifests/dev/manifest.yml
+++ b/manifests/dev/manifest.yml
@@ -1,0 +1,15 @@
+---
+defaults: &defaults
+  no-route: true
+  health-check-type: process
+  memory: 1G
+  disk_quota: 2G
+  docker:
+    image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev
+  services:
+    - federalist-dev-rds
+  command: bash ./run.sh
+
+applications:
+  - name: federalist-build-container-dev
+    <<: *defaults

--- a/manifests/dev/task-manifest.yml
+++ b/manifests/dev/task-manifest.yml
@@ -5,6 +5,6 @@ applications:
     health-check-type: process
     instances: 0
     docker:
-      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev
+      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev-task
     services:
       - federalist-dev-rds

--- a/manifests/dev/task-manifest.yml
+++ b/manifests/dev/task-manifest.yml
@@ -5,6 +5,6 @@ applications:
     health-check-type: process
     instances: 0
     docker:
-      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev-task
+      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build
     services:
       - federalist-dev-rds

--- a/manifests/dev/task-manifest.yml
+++ b/manifests/dev/task-manifest.yml
@@ -1,0 +1,10 @@
+---    
+applications:
+  - name: federalist-build-container-dev-task
+    no-route: true
+    health-check-type: process
+    instances: 0
+    docker:
+      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev
+    services:
+      - federalist-dev-rds

--- a/manifests/staging/task-manifest.yml
+++ b/manifests/staging/task-manifest.yml
@@ -5,6 +5,6 @@ applications:
     health-check-type: process
     instances: 0
     docker:
-      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build
+      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev-task
     services:
       - federalist-staging-rds

--- a/manifests/staging/task-manifest.yml
+++ b/manifests/staging/task-manifest.yml
@@ -5,6 +5,6 @@ applications:
     health-check-type: process
     instances: 0
     docker:
-      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build-dev-task
+      image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build
     services:
       - federalist-staging-rds


### PR DESCRIPTION
- Refactor task CLI to take all arguments as a JSON string for easier starting from federalist-builder
- add dev manifests
- update docker image publish in CircleCI to use correct image name
- update deploy script to take image name as an argument