### PR TITLE
[HOLD] Update default to node 12 and restrict versions with helpful errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ ENV LC_ALL en_US.UTF-8
 
 RUN dpkg-reconfigure --frontend noninteractive locales
 
-# Install nvm and install versions 8 and 10
+# Install nvm and node versions 10, 12
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_DEFAULT_VERSION 10
+ENV NODE_DEFAULT_VERSION 12
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
   && . "$NVM_DIR/nvm.sh" \
   && nvm install $NODE_DEFAULT_VERSION \
-  && nvm install 8 \
+  && nvm install 10 \
   && nvm use $NODE_DEFAULT_VERSION \
   && echo 'export OLD_PREFIX=$PREFIX && unset PREFIX' > $HOME/.profile \
   && echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' >> $HOME/.profile \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 100

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -37,6 +37,7 @@ GEMFILE = 'Gemfile'
 JEKYLL_CONFIG_YML = '_config.yml'
 BUNDLER_VERSION = '.bundler-version'
 
+
 def has_federalist_script():
     '''
     Checks for existence of the "federalist" script in the
@@ -75,8 +76,8 @@ def setup_node(ctx):
                             f'supports {", ".join(NODE_VERSIONS)}.'
                           )
                 if major_version != str(NODE_DEFAULT_VERSION):
-                    print(f'Found {nvmrc} in .nvmrc, switching to latest minor '
-                          f'version for {major_version}.')
+                    print(f'Found {nvmrc} in .nvmrc, switching to latest minor'
+                          f' version for {major_version}.')
                     ctx.run(f'nvm alias default {major_version}')
             else:
                 print(f'No .nvmrc found, using default node {NODE_DEFAULT_VERSION}')

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -67,7 +67,7 @@ def setup_node(ctx):
             if NVMRC_PATH.is_file():
                 nvmrc = ''
                 with open(NVMRC_PATH) as f:
-                    nvmrc = f.read()
+                    nvmrc = shlex.quote(f.readline().strip())
                 major_version = nvmrc.split('.')[0]
                 if major_version not in NODE_VERSIONS:
                     raise RuntimeError(


### PR DESCRIPTION
- Sets default node version to 12
- Pre installs node 10 and 12
- Restricts node versions to only the preinstalled versions
- If present, uses only the MAJOR version of the version specified in .nvmrc
- Helpful error messages (though it would be nice to omit the stack trace for known errors)

Companion Docs PR https://github.com/18F/federalist.18f.gov/pull/413