### PR TITLE
269 reduce docker size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
               only:
                 - staging
                 - main
-      - build-and-deploy-exp:
+      - build-and-deploy:
           app: federalist-build-container-exp
           image: federalist-garden-build-exp
           dockerfile: Dockerfile-exp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,13 @@ jobs:
   
   build-and-deploy:
     machine: true
+    parameters:
+      app:
+        type: string      
+      image:
+        type: string
+      dockerfile:
+        type: string
     environment:
       CF_MANIFEST: ./.cloudgov/manifest.yml    
     steps:
@@ -55,7 +62,7 @@ jobs:
       - run:
           name: Build docker image
           command: |
-            docker build -t federalist-garden-build .
+            docker build -t << parameters.image >> -f << parameters.dockerfile >> .
 
       - when:
           condition:
@@ -70,7 +77,7 @@ jobs:
                 echo "export CF_USERNAME=$CF_USERNAME_STAGING" >> $BASH_ENV
                 echo "export CF_PASSWORD=$CF_PASSWORD_STAGING" >> $BASH_ENV
                 echo "export CF_SPACE=staging" >> $BASH_ENV
-                echo "export CF_APP=federalist-build-container-staging" >> $BASH_ENV
+                echo "export CF_APP=<< parameters.app >>-staging" >> $BASH_ENV
                 echo "export CF_VARS_FILE=./.cloudgov/vars/staging.yml" >> $BASH_ENV     
            
       - when:
@@ -86,7 +93,7 @@ jobs:
                 echo "export CF_USERNAME=$CF_USERNAME_PRODUCTION" >> $BASH_ENV
                 echo "export CF_PASSWORD=$CF_PASSWORD_PRODUCTION" >> $BASH_ENV
                 echo "export CF_SPACE=production" >> $BASH_ENV
-                echo "export CF_APP=federalist-build-container" >> $BASH_ENV
+                echo "export CF_APP=<< parameters.app >>" >> $BASH_ENV
                 echo "export CF_VARS_FILE=./.cloudgov/vars/production.yml" >> $BASH_ENV
 
       - run:
@@ -104,12 +111,12 @@ jobs:
       - run:
           name: Tag docker image as latest for registry
           command: |
-            docker tag federalist-garden-build localhost:5000/federalist-garden-build
+            docker tag << parameters.image >> localhost:5000/<< parameters.image >>
       
       - run:
           name: Push docker image to registry
           command: |
-            docker push localhost:5000/federalist-garden-build
+            docker push localhost:5000/<< parameters.image >>
 
       - deploy:
           command: ./.cloudgov/deploy.sh
@@ -121,6 +128,9 @@ workflows:
     jobs:
       - test
       - build-and-deploy:
+          app: federalist-build-container
+          image: federalist-garden-build
+          dockerfile: Dockerfile
           requires:
             - test
           filters:
@@ -128,3 +138,14 @@ workflows:
               only:
                 - staging
                 - main
+      - build-and-deploy-exp:
+          app: federalist-build-container-exp
+          image: federalist-garden-build-exp
+          dockerfile: Dockerfile-exp
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - staging
+                - main                

--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -1,11 +1,20 @@
 ---    
 applications:
-  - name: ((name))
+  - name: federalist-build-container((env_postfix))
     no-route: true
     health-check-type: process
     instances: 0
     docker:
       image: ((image))
+    services:
+      - federalist-((env))-rds
+      - federalist-((env))-uev-key
+  - name: federalist-build-container-exp((env_postfix))
+    no-route: true
+    health-check-type: process
+    instances: 0
+    docker:
+      image: ((image))-exp
     services:
       - federalist-((env))-rds
       - federalist-((env))-uev-key

--- a/.cloudgov/vars/dev.yml
+++ b/.cloudgov/vars/dev.yml
@@ -1,3 +1,3 @@
-name: federalist-build-container-dev
 env: dev
+env_postfix: -dev
 image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build

--- a/.cloudgov/vars/production.yml
+++ b/.cloudgov/vars/production.yml
@@ -1,3 +1,3 @@
-name: federalist-build-container
 env: production
+env_postfix: ''
 image: federalist-registry.fr.cloud.gov/federalist-garden-build

--- a/.cloudgov/vars/staging.yml
+++ b/.cloudgov/vars/staging.yml
@@ -1,3 +1,3 @@
-name: federalist-build-container-staging
 env: staging
+env_postfix: -staging
 image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build

--- a/Dockerfile-exp
+++ b/Dockerfile-exp
@@ -1,0 +1,61 @@
+#################
+#  Build Image  #
+#################
+FROM python:3.8-buster AS builder
+WORKDIR /app
+RUN pip install pyinstaller staticx patchelf-wrapper
+COPY ./src ./requirements.txt ./
+RUN pip install -r requirements.txt
+RUN \
+  pyinstaller -F -n tmp-build --distpath ./dist --hidden-import='pkg_resources.py2_warn' ./main.py \
+  && staticx ./dist/tmp-build ./dist/build
+
+#################
+#  Final Image  #
+#################
+FROM ruby:2.7-slim
+
+RUN \
+  apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    gnupg \
+    dirmngr \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-l", "-c"]
+
+ENV RUBY_VERSION 2.7
+RUN \
+  gpg --keyserver hkp://ipv4.pool.sks-keyservers.net \
+    --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+  && \curl -sSL https://get.rvm.io | bash -s stable \
+  && echo 'source /usr/local/rvm/scripts/rvm' >> $HOME/.bashrc
+
+RUN \
+  rvm install $RUBY_VERSION \
+  && rvm use --default $RUBY_VERSION \
+  && echo 'rvm_silence_path_mismatch_check_flag=1' >> /etc/rvmrc
+
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_DEFAULT_VERSION 10
+RUN \
+  curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
+  && . "$NVM_DIR/nvm.sh" \
+  && nvm install $NODE_DEFAULT_VERSION \
+  && nvm use $NODE_DEFAULT_VERSION
+
+# Install headless chrome
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && apt-get update \
+  && apt-get install -y google-chrome-unstable --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/dist/build .
+
+CMD ["./build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 version: '3'
 services:
+  exp:
+    build:
+      context: .
+      dockerfile: Dockerfile-exp
+    volumes:
+      - ./.local:/tmp/local:ro
+    links:
+      - echoserver
+      - db
+    depends_on:
+      - echoserver
+      - db
+    environment:
+      CACHE_CONTROL: max-age=60
+      DATABASE_URL: postgresql://postgres:password@db/federalist
+      USER_ENVIRONMENT_VARIABLE_KEY: shhhhhhh
+
   app:
     build:
       context: .

--- a/src/build.py
+++ b/src/build.py
@@ -1,6 +1,7 @@
 '''Main entrypoint'''
 
 import os
+import sys
 from datetime import datetime
 from stopit import TimeoutException, SignalTimeout as Timeout
 
@@ -175,7 +176,7 @@ def build(
             # Finished!
             post_build_complete(status_callback, federalist_builder_callback)
 
-            exit(0)
+            sys.exit(0)
 
     except StepException as err:
         '''
@@ -184,7 +185,7 @@ def build(
         '''
         logger.error(str(err))
         post_build_error(status_callback, federalist_builder_callback, str(err))
-        exit(1)
+        sys.exit(1)
 
     except TimeoutException:
         logger.warning(f'Build({build_info}) has timed out')


### PR DESCRIPTION
Adds an additional experimental build container that leverages our python build code as a static executable with a Ruby-slim base image. This reduces overall size of the image by about 700 MB. We can reduce this by another 360 MB by creating a separate container for builds that require Chrome.

If we want to go further down the rabbit hole of different images, we could move to alpine image with specific ruby versions, but this won't work when ruby needs to be installed during the build because premade ruby binaries are not available via rvm (def. possible there is a solution to this).

This will deploy a second cloud foundry app that uses the build container. As a follow up, we'll need a way in the federalist builder to use the desired build container. 