### PR TITLE
Deploy from ECR in staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
           command: |
             docker push localhost:5000/<< parameters.image >>
   
+
   build-and-deploy-ecr:
     machine: true
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,16 +121,6 @@ jobs:
       - deploy:
           command: ./.cloudgov/deploy.sh
 
-          - run:
-            name: Authenticate with ECR
-            command: |
-              aws ecr get-login-password --region us-gov-west-1 | docker login --username AWS --password-stdin 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com
-
-      - run:
-          name: Authenticate with ECR
-          command: |
-            docker push localhost:5000/<< parameters.image >>
-  
 
   build-and-deploy-ecr:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,83 @@ jobs:
       - deploy:
           command: ./.cloudgov/deploy.sh
 
+          - run:
+            name: Authenticate with ECR
+            command: |
+              aws ecr get-login-password --region us-gov-west-1 | docker login --username AWS --password-stdin 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com
+
+      - run:
+          name: Authenticate with ECR
+          command: |
+            docker push localhost:5000/<< parameters.image >>
+  
+  build-and-deploy-ecr:
+    machine: true
+    parameters:
+      app:
+        type: string      
+      image:
+        type: string
+      dockerfile:
+        type: string
+    environment:
+      CF_MANIFEST: ./.cloudgov/manifest.yml    
+    steps:
+      - checkout
+
+      - run:
+          name: Build docker image
+          command: |
+            docker build -t << parameters.image >> -f << parameters.dockerfile >> .
+
+      - when:
+          condition:
+            equal: [ staging, << pipeline.git.branch >> ]
+          steps:
+            run:
+              name: Setup Staging Environment
+              command: |
+                echo "export CF_USERNAME=$CF_USERNAME_STAGING" >> $BASH_ENV
+                echo "export CF_PASSWORD=$CF_PASSWORD_STAGING" >> $BASH_ENV
+                echo "export CF_SPACE=staging" >> $BASH_ENV
+                echo "export CF_APP=<< parameters.app >>-staging" >> $BASH_ENV
+                echo "export CF_VARS_FILE=./.cloudgov/vars/staging.yml" >> $BASH_ENV     
+           
+      # - when:
+      #     condition:
+      #       equal: [ main, << pipeline.git.branch >> ]
+      #     steps:
+      #       run:
+      #         name: Setup Production Environment
+      #         command: |
+      #           echo "export CF_USERNAME=$CF_USERNAME_PRODUCTION" >> $BASH_ENV
+      #           echo "export CF_PASSWORD=$CF_PASSWORD_PRODUCTION" >> $BASH_ENV
+      #           echo "export CF_SPACE=production" >> $BASH_ENV
+      #           echo "export CF_APP=<< parameters.app >>" >> $BASH_ENV
+      #           echo "export CF_VARS_FILE=./.cloudgov/vars/production.yml" >> $BASH_ENV
+
+      - run:
+          name: Authenticate with ECR
+          command: |
+            echo "export AWS_ACCESS_KEY_ID=$AWS_ECR_WRITE_KEY" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$AWS_ECR_WRITE_SECRET" >> $BASH_ENV
+            aws ecr get-login-password --region us-gov-west-1 | docker login --username AWS --password-stdin 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com
+
+      - run:
+          name: Tag docker image
+          command: |
+            docker tag << parameters.image >> 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com/federalist/garden-build:staging
+                
+      - run:
+          name: Push docker image to registry
+          command: |
+            docker push 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com/federalist/garden-build:staging
+
+      - deploy:
+          command: |
+            echo "export CF_DOCKER_PASSWORD=$AWS_ECR_READ_SECRET" >> $BASH_ENV
+            ./.cloudgov/deploy.sh
+
 
 workflows:
   version: 2
@@ -136,7 +213,6 @@ workflows:
           filters:
             branches:
               only:
-                - staging
                 - main
       - build-and-deploy:
           app: federalist-build-container-exp
@@ -147,5 +223,24 @@ workflows:
           filters:
             branches:
               only:
+                - main
+      - build-and-deploy-ecr:
+          app: federalist-build-container
+          image: federalist-garden-build
+          dockerfile: Dockerfile
+          requires:
+            - test
+          filters:
+            branches:
+              only:
                 - staging
-                - main                
+      - build-and-deploy-ecr:
+          app: federalist-build-container-exp
+          image: federalist-garden-build-exp
+          dockerfile: Dockerfile-exp
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - staging

--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -6,6 +6,7 @@ applications:
     instances: 0
     docker:
       image: ((image))
+      username: AKIAWNYQRJFGHBAWM5MI
     services:
       - federalist-((env))-rds
       - federalist-((env))-uev-key
@@ -21,6 +22,7 @@ applications:
     instances: 0
     docker:
       image: ((image))-exp
+      username: AKIAWNYQRJFGHBAWM5MI
     services:
       - federalist-((env))-rds
       - federalist-((env))-uev-key

--- a/.cloudgov/vars/dev.yml
+++ b/.cloudgov/vars/dev.yml
@@ -1,3 +1,3 @@
 env: dev
 env_postfix: -dev
-image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build
+image: localhost:5000/federalist-garden-build

--- a/.cloudgov/vars/dev.yml
+++ b/.cloudgov/vars/dev.yml
@@ -1,3 +1,3 @@
 env: dev
 env_postfix: -dev
-image: localhost:5000/federalist-garden-build
+image: 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com/federalist/garden-build:staging

--- a/.cloudgov/vars/staging.yml
+++ b/.cloudgov/vars/staging.yml
@@ -1,3 +1,3 @@
 env: staging
 env_postfix: -staging
-image: localhost:5000/federalist-garden-build
+image: 441879447884.dkr.ecr.us-gov-west-1.amazonaws.com/federalist/garden-build:staging

--- a/.cloudgov/vars/staging.yml
+++ b/.cloudgov/vars/staging.yml
@@ -1,3 +1,3 @@
 env: staging
 env_postfix: -staging
-image: federalist-registry-staging.fr.cloud.gov/federalist-garden-build
+image: localhost:5000/federalist-garden-build


### PR DESCRIPTION
Updated to use ECR for staging.

A single ECR "repository" named `federalist/garden-build` has been configured in GovCloud `us-gov-west-1` (441879447884) to store our images. For now, I am tagging the images `staging` and `production` (eventually) for the appropriate environments to minimize the disruption to our current workflow. At some point, we can modify our process to version the images and perhaps turn on "tag immutability" on the ECR "repository" to enforce this which allow us to ensure that the same image tested in staging is the one actually promoted to production.

I have configured individual and attempted least-privileged read (`federalist-ecr-read`) and write (`federalist-ecr-write`) IAM users/policies that have appropriate access to ALL ECR "repositories" for this account (we currently only have the one). The "read" user is used when deploying the image to cloud.gov which is apparently cached by the platform so the image can be refetched during restarts and restages.