### PR TITLE
Support Yarn as alternative to NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,17 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get install -y google-chrome-unstable --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
+# Install Yarn
+ENV YARN_VERSION 1.22.5
+RUN curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
 WORKDIR /app
 
 COPY ./requirements.txt ./requirements.txt

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -17,6 +17,7 @@ from runner import run
 HUGO_BIN = 'hugo'
 HUGO_VERSION = '.hugo-version'
 NVMRC = '.nvmrc'
+YARN_LOCKFILE = 'yarn.lock'
 PACKAGE_JSON = 'package.json'
 RUBY_VERSION = '.ruby-version'
 GEMFILE = 'Gemfile'
@@ -115,12 +116,17 @@ def setup_node():
             logger.info('Using default node version')
             runp('echo Node version: $(node --version)')
             runp('echo NPM version: $(npm --version)')
+            runp('echo Yarn version: $(yarn --version)')
 
         PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON
         if PACKAGE_JSON_PATH.is_file():
             logger.info('Installing production dependencies in package.json')
-            runp('npm set audit false')
-            runp('npm ci --production')
+            YARN_LOCKFILE_PATH = CLONE_DIR_PATH / YARN_LOCKFILE
+            if YARN_LOCKFILE_PATH.is_file():
+                runp('yarn install --production --frozen-lockfile')
+            else:
+                runp('npm set audit false')
+                runp('npm ci --production')
 
     except (CalledProcessError, OSError, ValueError):
         return 1


### PR DESCRIPTION
Forewarning: I have no idea what I'm doing.

This pull request aims to allow Federalist to build sites using Yarn as an alternative package manager to NPM when the project being built contains a `yarn.lock` file in the cloned directory.

The goal is to support projects which use Yarn as a package manager, where currently these projects must include both `package-lock.json` and `yarn.lock` ([example](https://github.com/18F/identity-site)), which causes warnings in local development†. Removing `package-lock.json` causes Federalist build failures ([example log](https://federalistapp.18f.gov/sites/85/builds/152835/logs)).

The `Dockerfile` revisions were inspired by command instructions from the [official Node.js Debian `Dockerfile` template](https://github.com/nodejs/docker-node/blob/master/Dockerfile-debian.template).

† "warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files."