### PR TITLE
Restrict node versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN dpkg-reconfigure --frontend noninteractive locales
 # Default to Node 12 (erbium)
 ENV NVM_DIR /usr/local/nvm
 RUN mkdir $NVM_DIR \
-  && curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash \
+  && curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
   && . "$NVM_DIR/nvm.sh" \
   && nvm install 'lts/erbium'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,12 @@ ENV LC_ALL en_US.UTF-8
 
 RUN dpkg-reconfigure --frontend noninteractive locales
 
-# Install nvm and install versions 8 and 10
+# Default to Node 12 (erbium)
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_DEFAULT_VERSION 10
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
+RUN mkdir $NVM_DIR \
+  && curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash \
   && . "$NVM_DIR/nvm.sh" \
-  && nvm install $NODE_DEFAULT_VERSION \
-  && nvm install 8 \
-  && nvm use $NODE_DEFAULT_VERSION
+  && nvm install 'lts/erbium'
 
 # Install ruby via rvm
 ENV RUBY_VERSION 2.6.6

--- a/Dockerfile-exp
+++ b/Dockerfile-exp
@@ -41,7 +41,7 @@ RUN \
 # Default to Node 12 (erbium)
 ENV NVM_DIR /usr/local/nvm
 RUN mkdir $NVM_DIR \
-  && curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash \
+  && curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
   && . "$NVM_DIR/nvm.sh" \
   && nvm install 'lts/erbium'
 

--- a/Dockerfile-exp
+++ b/Dockerfile-exp
@@ -38,13 +38,12 @@ RUN \
   && rvm use --default $RUBY_VERSION \
   && echo 'rvm_silence_path_mismatch_check_flag=1' >> /etc/rvmrc
 
+# Default to Node 12 (erbium)
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_DEFAULT_VERSION 10
-RUN \
-  curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
+RUN mkdir $NVM_DIR \
+  && curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash \
   && . "$NVM_DIR/nvm.sh" \
-  && nvm install $NODE_DEFAULT_VERSION \
-  && nvm use $NODE_DEFAULT_VERSION
+  && nvm install 'lts/erbium'
 
 # Install headless chrome
 RUN \

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -120,7 +120,7 @@ def setup_node():
                     echo "Please upgrade to LTS major version 12 or 14, see https://nodejs.org/en/about/releases/ for details."
                     exit 1
                 fi
-            """)
+            """)  # noqa: E501
         else:
             # output node and npm versions if the defaults are used
             logger.info('Using default node version')

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -107,9 +107,20 @@ def setup_node():
         NVMRC_PATH = CLONE_DIR_PATH / NVMRC
         if NVMRC_PATH.is_file():
             # nvm will output the node and npm versions used
-            logger.info('Using node version specified in .nvmrc')
-            runp('nvm install')
-            runp('nvm use')
+            logger.info('Checking node version specified in .nvmrc')
+            runp("""
+                RAW_VERSION=$(nvm version-remote $(cat .nvmrc))
+                MAJOR_VERSION=$(echo $RAW_VERSION | cut -d. -f 1 | cut -dv -f 2)
+                if [[ "$MAJOR_VERSION" =~ ^(10|12|14)$ ]]; then
+                    echo "Using specified node version $RAW_VERSION"
+                    nvm install $RAW_VERSION
+                    nvm use $RAW_VERSION
+                else
+                    echo "Unsupported node major version '$MAJOR_VERSION' specified in .nvmrc."
+                    echo "Please upgrade to LTS major version 12 or 14, see https://nodejs.org/en/about/releases/ for details."
+                    exit 1
+                fi
+            """)
         else:
             # output node and npm versions if the defaults are used
             logger.info('Using default node version')

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -53,7 +53,7 @@ class TestSetupNode():
         mock_logger = mock_get_logger.return_value
 
         mock_logger.info.assert_called_with(
-            'Using node version specified in .nvmrc'
+            'Checking node version specified in .nvmrc'
         )
 
         def callp(cmd):

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -56,14 +56,6 @@ class TestSetupNode():
             'Checking node version specified in .nvmrc'
         )
 
-        def callp(cmd):
-            return call(mock_logger, cmd, cwd=patch_clone_dir, env={}, check=True, node=True)
-
-        mock_run.assert_has_calls([
-            callp('nvm install'),
-            callp('nvm use')
-        ])
-
     def test_installs_production_deps(self, mock_get_logger, mock_run, patch_clone_dir):
         create_file(patch_clone_dir / PACKAGE_JSON)
 


### PR DESCRIPTION
Resolves #287 

@amirbey @apburnes Wanted to get y'alls thoughts on this. Sets the default Node version to 12 (seemed like its probably the one most folks are using) and restricts usage to only LTS major versions (10, 12, 14), but allows install and use of any version for those majors. I'm trying to strike a balance between enforcement and flexibility.

Tests are still a TODO