### PR TITLE
Set default node version for use outside of federalist json step

### DIFF
--- a/src/runner/__init__.py
+++ b/src/runner/__init__.py
@@ -19,7 +19,7 @@ def run(logger, command, cwd=None, env=None, shell=False, check=False, node=Fals
 
     # TODO - refactor to put the appropriate node/npm binaries in PATH so this isn't necessary
     if node:
-        command = f'source {NVM_PATH} && {command}'
+        command = f'source {NVM_PATH} && nvm use default && {command}'
         shell = True
 
     # TODO - refactor to put the appropriate bundler binaries in PATH so this isn't necessary

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -210,7 +210,7 @@ def test_run_with_node(mock_popen):
     run(mock_logger, command, cwd=cwd, env=env, node=True)
 
     mock_popen.assert_called_once_with(
-        f'source {NVM_PATH} && {command}',
+        f'source {NVM_PATH} && nvm use default && {command}',
         cwd=cwd,
         env=env,
         shell=True,  # nosec


### PR DESCRIPTION
Addresses a potential issue raised by Scorecard where node things used from other steps in the build were not using the configured node version from the `setup-node` step. Here we set the selected version as the `default` and always call `nvm use default` in future shells requiring node.

Also updates the logging output to be a bit clearer and address a small bug I had locally when testing.