### PR TITLE
Configurably exclude files from publication

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,3 +8,4 @@ exclude_patterns:
   - "bin"
   - "main.py"
   - "manifests"
+  - "test"

--- a/src/build.py
+++ b/src/build.py
@@ -108,7 +108,10 @@ def build(
 
             federalist_config = repo_config.from_json_file(
                 CLONE_DIR_PATH,
-                dict(headers=dict([('cache-control', cache_control)]))
+                dict(
+                    headers=dict([('cache-control', cache_control)]),
+                    excludePaths=['/Dockerfile', '/docker-compose.yml']
+                )
             )
 
             if federalist_config.full_clone():

--- a/src/build.py
+++ b/src/build.py
@@ -110,7 +110,8 @@ def build(
                 CLONE_DIR_PATH,
                 dict(
                     headers=dict([('cache-control', cache_control)]),
-                    excludePaths=['/Dockerfile', '/docker-compose.yml']
+                    excludePaths=['**/Dockerfile', '**/docker-compose.yml'],
+                    includePaths=['/.well-known/security.txt']
                 )
             )
 

--- a/src/publishing/s3publisher.py
+++ b/src/publishing/s3publisher.py
@@ -70,6 +70,13 @@ def list_remote_objects(bucket, site_prefix, s3_client):
     return remote_objects
 
 
+def path_is_excluded(federalist_config, filename):
+    if 'Dockerfile' in filename or 'docker-compose.yml' in filename:
+        return True
+    else:
+        return False
+
+
 def get_cache_control(federalist_config, filename, dir_prefix):
     filepath = filename
     if dir_prefix and filepath.startswith(dir_prefix):
@@ -122,6 +129,10 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
                             site_prefix=site_prefix,
                             cache_control=cache_control)
         local_files.append(file_404)
+
+    # Exclude files based on defaults and configuration
+    local_files[:] = [file for file in local_files
+                      if not path_is_excluded(federalist_config, file.filename)]
 
     # Create a list of redirects from the local files
     local_redirects = []

--- a/src/publishing/s3publisher.py
+++ b/src/publishing/s3publisher.py
@@ -70,11 +70,12 @@ def list_remote_objects(bucket, site_prefix, s3_client):
     return remote_objects
 
 
-def path_is_excluded(federalist_config, filename):
-    if 'Dockerfile' in filename or 'docker-compose.yml' in filename:
-        return True
-    else:
-        return False
+def path_is_excluded(federalist_config, filename, dir_prefix):
+    filepath = filename
+    if dir_prefix and filepath.startswith(dir_prefix):
+        filepath = filepath[len(dir_prefix):]
+
+    return federalist_config.is_path_excluded(filepath)
 
 
 def get_cache_control(federalist_config, filename, dir_prefix):
@@ -132,7 +133,7 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
 
     # Exclude files based on defaults and configuration
     local_files[:] = [file for file in local_files
-                      if not path_is_excluded(federalist_config, file.filename)]
+                      if not path_is_excluded(federalist_config, file.filename, directory)]
 
     # Create a list of redirects from the local files
     local_redirects = []

--- a/src/publishing/s3publisher.py
+++ b/src/publishing/s3publisher.py
@@ -2,7 +2,6 @@
 Classes and methods for publishing a directory to S3
 '''
 
-# import glob
 import requests
 
 from os import path, makedirs, walk

--- a/src/publishing/s3publisher.py
+++ b/src/publishing/s3publisher.py
@@ -2,10 +2,10 @@
 Classes and methods for publishing a directory to S3
 '''
 
-import glob
+# import glob
 import requests
 
-from os import path, makedirs
+from os import path, makedirs, walk
 
 from log_utils import get_logger
 from .models import (remove_prefix, SiteObject, SiteFile, SiteRedirect)
@@ -70,20 +70,14 @@ def list_remote_objects(bucket, site_prefix, s3_client):
     return remote_objects
 
 
-def path_is_excluded(federalist_config, filename, dir_prefix):
-    filepath = filename
-    if dir_prefix and filepath.startswith(dir_prefix):
-        filepath = filepath[len(dir_prefix):]
-
-    return federalist_config.is_path_excluded(filepath)
+def get_cache_control(federalist_config, filename):
+    return federalist_config.get_headers_for_path(filename).get('cache-control')
 
 
-def get_cache_control(federalist_config, filename, dir_prefix):
-    filepath = filename
-    if dir_prefix and filepath.startswith(dir_prefix):
-        filepath = filepath[len(dir_prefix):]
-
-    return federalist_config.get_headers_for_path(filepath).get('cache-control')
+def strip_dirname(filepath, dirname):
+    if dirname and filepath.startswith(dirname):
+        return filepath[len(dirname):]
+    return filepath
 
 
 def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
@@ -91,26 +85,29 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
     '''Publishes the given directory to S3'''
     logger = get_logger('publish')
 
-    # With glob, dotfiles are ignored by default
-    # Note that the filenames will include the `directory` prefix
-    # but we won't want that for the eventual S3 keys
-    files_and_dirs = glob.glob(path.join(directory, '**', '*'),
-                               recursive=True)
+    local_objects = []
 
-    # add security.txt support
-    files_and_dirs += glob.glob(path.join(directory, '**', '.well-known',
-                                'security.txt'), recursive=True)
     # Collect a list of all files in the specified directory
-    local_files = []
-    for filename in files_and_dirs:
-        if path.isfile(filename):
-            cache_control = get_cache_control(federalist_config, filename, directory)
+    for root, _dirs, filenames in walk(directory):
+        for filename in filenames:
+            full_path = path.join(root, filename)
+            relative_path = strip_dirname(full_path, directory)
 
-            site_file = SiteFile(filename=filename,
-                                 dir_prefix=directory,
-                                 site_prefix=site_prefix,
-                                 cache_control=cache_control)
-            local_files.append(site_file)
+            if federalist_config.is_path_included(relative_path):
+                cache_control = get_cache_control(federalist_config, relative_path)
+
+                site_file = SiteFile(filename=full_path,
+                                     dir_prefix=directory,
+                                     site_prefix=site_prefix,
+                                     cache_control=cache_control)
+                local_objects.append(site_file)
+
+                if filename == 'index.html':
+                    site_redirect = SiteRedirect(filename=root,
+                                                 dir_prefix=directory,
+                                                 site_prefix=site_prefix,
+                                                 base_url=base_url)
+                    local_objects.append(site_redirect)
 
     # Add local 404 if does not already exist
     filename_404 = directory + '/404.html'
@@ -123,31 +120,13 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
         with open(filename_404, "w+") as f:
             f.write(default_404.text)
 
-        cache_control = get_cache_control(federalist_config, filename_404, directory)
+        cache_control = get_cache_control(federalist_config, strip_dirname(filename_404, directory))
 
         file_404 = SiteFile(filename=filename_404,
                             dir_prefix=directory,
                             site_prefix=site_prefix,
                             cache_control=cache_control)
-        local_files.append(file_404)
-
-    # Exclude files based on defaults and configuration
-    local_files[:] = [file for file in local_files
-                      if not path_is_excluded(federalist_config, file.filename, directory)]
-
-    # Create a list of redirects from the local files
-    local_redirects = []
-    for site_file in local_files:
-        if path.basename(site_file.filename) == 'index.html':
-            redirect_filename = path.dirname(site_file.filename)
-            site_redirect = SiteRedirect(filename=redirect_filename,
-                                         dir_prefix=directory,
-                                         site_prefix=site_prefix,
-                                         base_url=base_url)
-            local_redirects.append(site_redirect)
-
-    # Combined list of local objects
-    local_objects = local_files + local_redirects
+        local_objects.append(file_404)
 
     if len(local_objects) == 0:
         raise RuntimeError('Local build files not found')
@@ -186,7 +165,7 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
     ]
 
     if (len(new_objects) == 0 and len(replacement_objects) <= 1 and
-            len(local_files) <= 1):
+            len(local_objects) <= 1):
         raise RuntimeError('Cannot unpublish all files')
 
     logger.info('Preparing to upload')

--- a/src/repo_config/repo_config.py
+++ b/src/repo_config/repo_config.py
@@ -197,7 +197,4 @@ def strip_prefix(prefix, path):
 
 
 def prepend_slash(path):
-    if path[0] == '/':
-        return path
-
-    return '/' + path
+    return path if path.startswith('/') else ('/' + path)

--- a/src/repo_config/repo_config.py
+++ b/src/repo_config/repo_config.py
@@ -10,13 +10,13 @@ class RepoConfig:
                 "cache-control": "no-cache"
             }
         ]
-        "exclude": [
-            "/excluded_file": true,
-            "/another_excluded_file": true
+        "excludePaths": [
+            "/excluded_file",
+            "/another_excluded_file",
         ]
     }
 
-    Currently, only the `headers`, `exclude`, and `fullClone` keys are read and used
+    Currently, only the `headers`, `excludePaths`, and `fullClone` keys are read and used
     '''
 
     def __init__(self, config={}, defaults={}):
@@ -24,11 +24,11 @@ class RepoConfig:
         self.defaults = defaults
         # The following defaults can be overridden by rules for these
         # patterns defined earlier in the configuration file or object.
-        if 'exclude' not in self.config:
-            self.config['exclude'] = []
+        if 'excludePaths' not in self.config:
+            self.config['excludePaths'] = []
 
-        self.config['exclude'].append({'/Dockerfile': True})
-        self.config['exclude'].append({'/docker-compose.yml': True})
+        self.config['excludePaths'].append('/Dockerfile')
+        self.config['excludePaths'].append('/docker-compose.yml')
 
     def get_headers_for_path(self, path_to_match):
         '''
@@ -55,14 +55,9 @@ class RepoConfig:
         Determine whether the filepath should be excluded from publication
         '''
 
-        first_matching_cfg = find_first_matching_cfg(
-            self.config.get('exclude', []),
-            path_to_match)
+        exclude_paths = self.config.get('excludePaths', [])
 
-        if first_matching_cfg and len(first_matching_cfg) > 0:
-            return first_value(first_matching_cfg)
-        else:
-            return False
+        return any([match_path(exclude_path, path_to_match) for exclude_path in exclude_paths])
 
     def full_clone(self):
         return self.config.get('fullClone', False) is True

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -185,3 +185,11 @@ def test_publish_to_s3(tmpdir, s3_client):
         publish_to_s3(**publish_kwargs)
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
         assert results['KeyCount'] == 6
+
+        # make sure default excluded files are excluded by default
+        more_filenames = ['Dockerfile',
+                          'docker-compose.yml']
+        _make_fake_files(test_dir, more_filenames)
+        publish_to_s3(**publish_kwargs)
+        results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+        assert results['KeyCount'] == 6

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -91,8 +91,8 @@ def test_publish_to_s3(tmpdir, s3_client):
                 {'/index.html': {'cache-control': 'no-cache'}},
                 {'/*.txt': {'cache-control': 'max-age=1000'}}
             ],
-            'exclude': [
-                {'/excluded-file': True}
+            'excludePaths': [
+                '/excluded-file'
             ]
         },
         dict(headers=dict([('cache-control', 'max-age=60')]))

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -100,8 +100,11 @@ def test_publish_to_s3(tmpdir, s3_client):
                 'cache-control': 'max-age=60'
             },
             'excludePaths': [
-                '/Dockerfile',
-                '/docker-compose.yml'
+                '**/Dockerfile',
+                '**/docker-compose.yml'
+            ],
+            'includePaths': [
+                '/.well-known/security.txt'
             ]
         }
     )
@@ -195,6 +198,7 @@ def test_publish_to_s3(tmpdir, s3_client):
         _make_fake_files(test_dir, more_filenames)
         publish_to_s3(**publish_kwargs)
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+        print(results)
         assert results['KeyCount'] == 6
 
         # make sure default excluded files are excluded by default

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -95,7 +95,15 @@ def test_publish_to_s3(tmpdir, s3_client):
                 '/excluded-file'
             ]
         },
-        dict(headers=dict([('cache-control', 'max-age=60')]))
+        {
+            'headers': {
+                'cache-control': 'max-age=60'
+            },
+            'excludePaths': [
+                '/Dockerfile',
+                '/docker-compose.yml'
+            ]
+        }
     )
 
     publish_kwargs = {

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -90,6 +90,9 @@ def test_publish_to_s3(tmpdir, s3_client):
             'headers': [
                 {'/index.html': {'cache-control': 'no-cache'}},
                 {'/*.txt': {'cache-control': 'max-age=1000'}}
+            ],
+            'exclude': [
+                {'/excluded-file': True}
             ]
         },
         dict(headers=dict([('cache-control', 'max-age=60')]))
@@ -189,6 +192,13 @@ def test_publish_to_s3(tmpdir, s3_client):
         # make sure default excluded files are excluded by default
         more_filenames = ['Dockerfile',
                           'docker-compose.yml']
+        _make_fake_files(test_dir, more_filenames)
+        publish_to_s3(**publish_kwargs)
+        results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
+        assert results['KeyCount'] == 6
+
+        # make sure files can be excluded in configuration
+        more_filenames = ['excluded-file']
         _make_fake_files(test_dir, more_filenames)
         publish_to_s3(**publish_kwargs)
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -198,7 +198,6 @@ def test_publish_to_s3(tmpdir, s3_client):
         _make_fake_files(test_dir, more_filenames)
         publish_to_s3(**publish_kwargs)
         results = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
-        print(results)
         assert results['KeyCount'] == 6
 
         # make sure default excluded files are excluded by default

--- a/test/repo_config/test_repo_config.py
+++ b/test/repo_config/test_repo_config.py
@@ -151,7 +151,15 @@ def test_is_path_excluded():
             '/excluded-file',
         ]
     }
-    repo_config = RepoConfig(config=config, defaults={})
+
+    defaults = {
+        'excludePaths': [
+            '/Dockerfile',
+            '/docker-compose.yml'
+        ]
+    }
+
+    repo_config = RepoConfig(config=config, defaults=defaults)
 
     # Excludes a file explicitly excluded
     value = repo_config.is_path_excluded('/excluded-file')
@@ -161,20 +169,21 @@ def test_is_path_excluded():
     value = repo_config.is_path_excluded('/index.html')
     assert value is not True
 
-    # Excludes Dockerfile by default when that file is not mentioned
+    # Excludes Dockerfile by default when that file is in defaults
     value = repo_config.is_path_excluded('/Dockerfile')
     assert value is True
 
-    # Excludes docker-compose.yml by default when that file is not mentioned
+    # Excludes docker-compose.yml by default when that file is in defaults
     value = repo_config.is_path_excluded('/docker-compose.yml')
     assert value is True
 
     config = {
-        'excludePaths': [
+        'includePaths': [
             '/Dockerfile',
         ]
     }
-    repo_config = RepoConfig(config=config, defaults={})
+
+    repo_config = RepoConfig(config=config, defaults=defaults)
 
     # Includes Dockerfile when that default is overridden by configuration
     value = repo_config.is_path_excluded('/Dockerfile')

--- a/test/repo_config/test_repo_config.py
+++ b/test/repo_config/test_repo_config.py
@@ -143,3 +143,39 @@ def test_get_headers_for_path():
     path_to_match = '/foo.js'
     value = repo_config.get_headers_for_path(path_to_match)
     assert value == defaults['headers']
+
+
+def test_is_path_excluded():
+    config = {
+        'exclude': [
+            {'/excluded-file': True},
+        ]
+    }
+    repo_config = RepoConfig(config=config, defaults={})
+
+    # Excludes a file explicitly excluded
+    value = repo_config.is_path_excluded('/excluded-file')
+    assert value is True
+
+    # Doesn't exclude a file not explicitly excluded
+    value = repo_config.is_path_excluded('/index.html')
+    assert value is not True
+
+    # Excludes Dockerfile by default when that file is not mentioned
+    value = repo_config.is_path_excluded('/Dockerfile')
+    assert value is True
+
+    # Excludes docker-compose.yml by default when that file is not mentioned
+    value = repo_config.is_path_excluded('/docker-compose.yml')
+    assert value is True
+
+    config = {
+        'exclude': [
+            {'/Dockerfile': False},
+        ]
+    }
+    repo_config = RepoConfig(config=config, defaults={})
+
+    # Includes Dockerfile when that default is overridden by configuration
+    value = repo_config.is_path_excluded('/Dockerfile')
+    assert value is not True

--- a/test/repo_config/test_repo_config.py
+++ b/test/repo_config/test_repo_config.py
@@ -147,8 +147,8 @@ def test_get_headers_for_path():
 
 def test_is_path_excluded():
     config = {
-        'exclude': [
-            {'/excluded-file': True},
+        'excludePaths': [
+            '/excluded-file',
         ]
     }
     repo_config = RepoConfig(config=config, defaults={})
@@ -170,8 +170,8 @@ def test_is_path_excluded():
     assert value is True
 
     config = {
-        'exclude': [
-            {'/Dockerfile': False},
+        'excludePaths': [
+            '/Dockerfile',
         ]
     }
     repo_config = RepoConfig(config=config, defaults={})

--- a/test/repo_config/test_repo_config.py
+++ b/test/repo_config/test_repo_config.py
@@ -1,4 +1,4 @@
-from repo_config.repo_config import (RepoConfig, match_path,
+from repo_config.repo_config import (RepoConfig, contains_dotpath, match_path,
                                      find_first_matching_cfg)
 
 
@@ -145,46 +145,173 @@ def test_get_headers_for_path():
     assert value == defaults['headers']
 
 
-def test_is_path_excluded():
-    config = {
-        'excludePaths': [
-            '/excluded-file',
-        ]
-    }
+def test_exclude_paths_always_returns_a_list():
+    repo_config = RepoConfig(config={}, defaults={})
+    value = repo_config.exclude_paths()
+    assert value == []
 
-    defaults = {
-        'excludePaths': [
-            '/Dockerfile',
-            '/docker-compose.yml'
-        ]
-    }
 
-    repo_config = RepoConfig(config=config, defaults=defaults)
+def test_exclude_paths_returns_union_of_config_and_defaults():
+    repo_config = RepoConfig(config=test_config(), defaults=test_defaults())
+    value = repo_config.exclude_paths()
+    assert value == [
+        '/excluded-file',
+        '**/Dockerfile',
+        '/docker-compose.yml'
+    ]
+
+
+def test_include_paths_always_returns_a_list():
+    repo_config = RepoConfig(config={}, defaults={})
+    value = repo_config.include_paths()
+    assert value == []
+
+
+def test_include_paths_returns_union_of_config_and_defaults():
+    repo_config = RepoConfig(config=test_config(), defaults=test_defaults())
+    value = repo_config.include_paths()
+    assert value == [
+        '/foo/Dockerfile',
+        '**/.foo',
+        '/.well-known/security.txt'
+    ]
+
+
+def test_is_exclude_path_match():
+    repo_config = RepoConfig(config=test_config(), defaults=test_defaults())
+
+    # Excludes default file anywhere
+    value = repo_config.is_exclude_path_match('/Dockerfile')
+    assert value is True
+
+    value = repo_config.is_exclude_path_match('/foo/Dockerfile')
+    assert value is True
+
+    # Excludes default file only at root
+    value = repo_config.is_exclude_path_match('/docker-compose.yml')
+    assert value is True
+
+    value = repo_config.is_exclude_path_match('/foo/docker-compose.yml')
+    assert value is False
 
     # Excludes a file explicitly excluded
-    value = repo_config.is_path_excluded('/excluded-file')
+    value = repo_config.is_exclude_path_match('/excluded-file')
     assert value is True
 
     # Doesn't exclude a file not explicitly excluded
-    value = repo_config.is_path_excluded('/index.html')
-    assert value is not True
+    value = repo_config.is_exclude_path_match('/index.html')
+    assert value is False
 
-    # Excludes Dockerfile by default when that file is in defaults
+
+def test_is_include_path_match():
+    repo_config = RepoConfig(config=test_config(), defaults=test_defaults())
+
+    # Includes default file only in root
+    value = repo_config.is_include_path_match('/.well-known/security.txt')
+    assert value is True
+
+    # Includes Dockerfile when that default is overridden by configuration
+    value = repo_config.is_include_path_match('/foo/Dockerfile')
+    assert value is True
+
+    # Includes dot file
+    value = repo_config.is_include_path_match('/foo/bar/.foo')
+    assert value is True
+
+
+def test_is_path_excluded():
+    repo_config = RepoConfig(config=test_config(), defaults=test_defaults())
+
+    # Excludes dotfiles
+    value = repo_config.is_path_excluded('/.bar')
+    assert value is True
+
+    value = repo_config.is_path_excluded('/foo/.bar')
+    assert value is True
+
+    # Includes dotfiles when specified
+    value = repo_config.is_path_excluded('/.well-known/security.txt')
+    assert value is False
+
+    value = repo_config.is_path_excluded('/bar/.foo')
+    assert value is False
+
+    # Excludes defaults
     value = repo_config.is_path_excluded('/Dockerfile')
     assert value is True
 
-    # Excludes docker-compose.yml by default when that file is in defaults
+    value = repo_config.is_path_excluded('/bar/Dockerfile')
+    assert value is True
+
     value = repo_config.is_path_excluded('/docker-compose.yml')
     assert value is True
 
-    config = {
+    value = repo_config.is_path_excluded('/foo/docker-compose.yml')
+    assert value is False
+
+    # Excludes configured
+    value = repo_config.is_path_excluded('/excluded-file')
+    assert value is True
+
+    value = repo_config.is_path_excluded('/foo/excluded-file')
+    assert value is False
+
+    # Includes configured that overrides default
+    value = repo_config.is_path_excluded('/foo/Dockerfile')
+    assert value is False
+
+    # Prepends slashes
+    value = repo_config.is_path_excluded('excluded-file')
+    assert value is True
+
+    value = repo_config.is_path_excluded('foo/excluded-file')
+    assert value is False
+
+
+def test_is_path_included_is_not_is_path_excluded():
+    repo_config = RepoConfig(config=test_config(), defaults=test_defaults())
+    path = '/bar/.foo'
+    included_value = repo_config.is_path_included(path)
+    excluded_value = repo_config.is_path_excluded(path)
+    assert included_value is not excluded_value
+
+
+def test_contains_dotpath():
+    value = contains_dotpath('/.foo')
+    assert value is True
+
+    value = contains_dotpath('/.foo/bar')
+    assert value is True
+
+    value = contains_dotpath('/foo/.bar')
+    assert value is True
+
+    value = contains_dotpath('/foo/.bar/baz')
+    assert value is True
+
+    value = contains_dotpath('/foo/bar')
+    assert value is False
+
+
+def test_config():
+    return {
+        'excludePaths': [
+            '/excluded-file'
+        ],
         'includePaths': [
-            '/Dockerfile',
+            '/foo/Dockerfile',
+            '**/.foo'
         ]
     }
 
-    repo_config = RepoConfig(config=config, defaults=defaults)
 
-    # Includes Dockerfile when that default is overridden by configuration
-    value = repo_config.is_path_excluded('/Dockerfile')
-    assert value is not True
+def test_defaults():
+    return {
+        'excludePaths': [
+            '**/Dockerfile',
+            '/docker-compose.yml'
+        ],
+        'includePaths': [
+            '/.well-known/security.txt'
+        ]
+    }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Look for `exclude` rules in a site's `federalist.json` and exclude any matching files from publication to S3. 
- The `federalist.json` configuration implementation reuses the existing (experimental) implementation for `headers`, uses the first matching rule (so more specific rules need to be listed first) and looks like this:
```
        "exclude": [
            "/excluded_file": true,
            "/another_excluded_file": true
        ]
```
- Exclude `/Dockerfile` and `/docker-compose.yml` by default, just as if these rules were defined:
```
        "exclude": [
            "/Dockerfile": true,
            "/docker-compose.yml": true
        ]
```
- Support _overriding_ the exclusion of `/Dockerfile` or `/docker-compose.yml` in case there is a case where a site specifically needs to make one of these downloadable. Overriding the default behavior for both would look like this:
```
        "exclude": [
            "/Dockerfile": false,
            "/docker-compose.yml": false
        ]
```

This is intended to address #343

## Important note:
So far as I have determined the existing directory/path matching (in `repo_config.py`) doesn't have a way to match a specific file name in an arbitrary directory. The default implementation here excludes `Dockerfile` and `docker-compose.yml` _specifically and only_ in the root folder: `/Dockerfile` and `docker-compose.yml`. Another option might be `*Dockerfile` and `*docker-compose.yml` but that could have (extremely unlikely) unwanted matches. If we do want to change them, these defaults are set in `__init__` in `repo_config.py`, where they are appended to `self.config`. *Further Note* (because I got tripped up by this myself): `self.defaults`, etc., are not suitable for this — they're for dealing with the default header key/value pairs that are associated with files, not for what we want here: an implicit set of default configuration rules.

## Further considerations before this is deployed:
- This changes the default behavior federalist publication, so
  - Any instances of `/Dockerfile` or `/docker-compose.yml` in existing Federalist sites will be deleted from S3 and not redeployed unless this default behavior is overridden in those sites' `federalist.json` files. There may or may not be any such instances, and even if there is it's probably correct to unpublish those files. But it would be a good idea to try and find out and notify potentially affected site maintainers if any are found.
  - The new behavior should be documented [here](https://federalist.18f.gov/documentation/federalist-json/) and that documentation published in coordination with production deployment of this change.

## security considerations
By removing `/Dockerfile` and `/docker-compose.yml` from unintentional publication, and potentially excluding other unwanted publication, this change reduces unnecessary exposure of site implementation and configuration details.