### PR TITLE
Use single star only

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -110,7 +110,7 @@ def build(
                 CLONE_DIR_PATH,
                 dict(
                     headers=dict([('cache-control', cache_control)]),
-                    excludePaths=['**/Dockerfile', '**/docker-compose.yml'],
+                    excludePaths=['*/Dockerfile', '*/docker-compose.yml'],
                     includePaths=['/.well-known/security.txt']
                 )
             )

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -100,8 +100,8 @@ def test_publish_to_s3(tmpdir, s3_client):
                 'cache-control': 'max-age=60'
             },
             'excludePaths': [
-                '**/Dockerfile',
-                '**/docker-compose.yml'
+                '*/Dockerfile',
+                '*/docker-compose.yml'
             ],
             'includePaths': [
                 '/.well-known/security.txt'

--- a/test/repo_config/test_repo_config.py
+++ b/test/repo_config/test_repo_config.py
@@ -156,6 +156,8 @@ def test_exclude_paths_returns_union_of_config_and_defaults():
     value = repo_config.exclude_paths()
     assert value == [
         '/excluded-file',
+        '/excluded-folder',
+        '/excluded-folder/*',
         '*/Dockerfile',
         '/docker-compose.yml'
     ]
@@ -252,11 +254,24 @@ def test_is_path_excluded():
     value = repo_config.is_path_excluded('/foo/docker-compose.yml')
     assert value is False
 
-    # Excludes configured
+    # Excludes configured files
     value = repo_config.is_path_excluded('/excluded-file')
     assert value is True
 
     value = repo_config.is_path_excluded('/foo/excluded-file')
+    assert value is False
+
+    # Excludes configured folders
+    value = repo_config.is_path_excluded('/excluded-folder')
+    assert value is True
+
+    value = repo_config.is_path_excluded('/excluded-folder/')
+    assert value is True
+
+    value = repo_config.is_path_excluded('/excluded-folder/foo.txt')
+    assert value is True
+
+    value = repo_config.is_path_excluded('/foo/excluded-folder/foo.txt')
     assert value is False
 
     # Includes configured that overrides default
@@ -299,7 +314,9 @@ def test_contains_dotpath():
 def test_config():
     return {
         'excludePaths': [
-            '/excluded-file'
+            '/excluded-file',
+            '/excluded-folder',
+            '/excluded-folder/*'
         ],
         'includePaths': [
             '/foo/Dockerfile',

--- a/test/repo_config/test_repo_config.py
+++ b/test/repo_config/test_repo_config.py
@@ -156,7 +156,7 @@ def test_exclude_paths_returns_union_of_config_and_defaults():
     value = repo_config.exclude_paths()
     assert value == [
         '/excluded-file',
-        '**/Dockerfile',
+        '*/Dockerfile',
         '/docker-compose.yml'
     ]
 
@@ -172,7 +172,7 @@ def test_include_paths_returns_union_of_config_and_defaults():
     value = repo_config.include_paths()
     assert value == [
         '/foo/Dockerfile',
-        '**/.foo',
+        '*/.foo',
         '/.well-known/security.txt'
     ]
 
@@ -185,6 +185,9 @@ def test_is_exclude_path_match():
     assert value is True
 
     value = repo_config.is_exclude_path_match('/foo/Dockerfile')
+    assert value is True
+
+    value = repo_config.is_exclude_path_match('/foo/bar/baz/Dockerfile')
     assert value is True
 
     # Excludes default file only at root
@@ -300,7 +303,7 @@ def test_config():
         ],
         'includePaths': [
             '/foo/Dockerfile',
-            '**/.foo'
+            '*/.foo'
         ]
     }
 
@@ -308,7 +311,7 @@ def test_config():
 def test_defaults():
     return {
         'excludePaths': [
-            '**/Dockerfile',
+            '*/Dockerfile',
             '/docker-compose.yml'
         ],
         'includePaths': [


### PR DESCRIPTION
## Changes proposed in this pull request:
- More for #343 
- We only need to use `*` not `**` which corresponds to the general understanding of `glob`s

## security considerations
None
