### PR TITLE
Add env_postfix -production to match pipeline deploy CF_APP name

### DIFF
--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -1,3 +1,3 @@
 env: production
-env_postfix: ''
+env_postfix: '-production'
 product: pages


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `env_postfix` to be `-production` to match name schema for CF_APP in pipeline deploy job.

## security considerations
None
