### PR TITLE
Use correct put resource and switch to just state params

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -101,13 +101,9 @@ jobs:
       - do: *test
 
     on_success:
-      put: src
+      put: gh-status
       inputs: [src]
-      params:
-        path: src
-        status: success
-        base_context: concourse
-        context: test-((deploy-env))
+      params: {state: success}
 
     on_failure:
       in_parallel:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use the correct put resource to gh-status and update to just use the state param like the on_failure. Tested in staging.

## security considerations
None
